### PR TITLE
Property based testing of the records layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyc
 .cache/
 .coverage
+.hypothesis/
 .tox/
 __pycache__/
 build/

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,10 @@ Changelog
 v1.0.1 (UNRELEASED)
 ===================
 
+- Record parsing and writing are now tested with an additional suite of
+  property based tests, using the Hypothesis library. This testing effort
+  identified a number of issues, all of which are fixed by this release.
+
 - Fixed exception in :meth:`netsgiro.records.TransactionAmountItem2.to_ocr()`
   if :attr:`~netsgiro.records.TransactionAmountItem2.payer_name` was
   :class:`None`.

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
             'check-manifest',
             'flake8',
             'flake8-import-order',
+            'hypothesis',
             'mypy',
             'pydocstyle',
             'pytest',

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -147,3 +147,73 @@ def test_assignment_end_for_avtalegiro_agreements(nt, nr):
 
     assert record.num_transactions == nt
     assert record.num_records == nr
+
+
+@given(
+    tn=st.integers(min_value=0, max_value=9999999),
+    nd=dates(),
+    a=st.integers(min_value=0),
+    kid=digits(25),  # TODO Alternatively shorter with leading space padding
+    cid=digits(2),
+    dc=st.integers(min_value=1, max_value=31),
+    psn=st.integers(min_value=0, max_value=9),
+    pssn=digits(5),
+    sign=st.one_of(st.just('0'), st.just('-')),
+)
+def test_transaction_amount_item_1_for_ocr_giro_transactions(
+        tn, nd, a, kid, cid, dc, psn, pssn, sign):
+    original = netsgiro.records.TransactionAmountItem1(
+        service_code=netsgiro.ServiceCode.OCR_GIRO,
+        transaction_type=netsgiro.TransactionType.FROM_GIRO_DEBITED_ACCOUNT,
+        transaction_number=tn,
+        nets_date=nd,
+        amount=a,
+        kid=kid,
+
+        centre_id=cid,
+        day_code=dc,
+        partial_settlement_number=psn,
+        partial_settlement_serial_number=pssn,
+        sign=sign,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.TransactionAmountItem1.from_string(ocr)
+
+    assert record.transaction_number == tn
+    assert record.nets_date == nd
+    assert record.amount == a
+    assert record.kid == kid
+
+    assert record.centre_id == cid
+    assert record.day_code == dc
+    assert record.partial_settlement_number == psn
+    assert record.partial_settlement_serial_number == pssn
+    assert record.sign == sign
+
+
+@given(
+    tn=st.integers(min_value=0, max_value=9999999),
+    nd=dates(),
+    a=st.integers(min_value=0),
+    kid=digits(25),  # TODO Alternatively shorter with leading space padding
+)
+def test_transaction_amount_item_1_for_avtalegiro_payment_requests(
+        tn, nd, a, kid):
+    original = netsgiro.records.TransactionAmountItem1(
+        service_code=netsgiro.ServiceCode.AVTALEGIRO,
+        transaction_type=(
+            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
+        transaction_number=tn,
+        nets_date=nd,
+        amount=a,
+        kid=kid,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.TransactionAmountItem1.from_string(ocr)
+
+    assert record.transaction_number == tn
+    assert record.nets_date == nd
+    assert record.amount == a
+    assert record.kid == kid

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -100,3 +100,50 @@ def test_assignment_start_for_avtalegiro_agreements(an, aa):
     assert record.agreement_id is None
     assert record.assignment_number == an
     assert record.assignment_account == aa
+
+
+@given(
+    nt=st.integers(min_value=0),
+    nr=st.integers(min_value=0),
+    ta=st.integers(min_value=0),
+    nd1=dates(),
+    nd2=dates(),
+)
+def test_assignment_end_for_avtalegiro_payment_requests(nt, nr, ta, nd1, nd2):
+    original = netsgiro.records.AssignmentEnd(
+        service_code=netsgiro.ServiceCode.AVTALEGIRO,
+        assignment_type=netsgiro.AssignmentType.TRANSACTIONS,
+        num_transactions=nt,
+        num_records=nr,
+        total_amount=ta,
+        nets_date_1=nd1,
+        nets_date_2=nd2,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.AssignmentEnd.from_string(ocr)
+
+    assert record.num_transactions == nt
+    assert record.num_records == nr
+    assert record.total_amount == ta
+    assert record.nets_date_earliest == nd1
+    assert record.nets_date_latest == nd2
+
+
+@given(
+    nt=st.integers(min_value=0),
+    nr=st.integers(min_value=0),
+)
+def test_assignment_end_for_avtalegiro_agreements(nt, nr):
+    original = netsgiro.records.AssignmentEnd(
+        service_code=netsgiro.ServiceCode.AVTALEGIRO,
+        assignment_type=netsgiro.AssignmentType.AVTALEGIRO_AGREEMENTS,
+        num_transactions=nt,
+        num_records=nr,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.AssignmentEnd.from_string(ocr)
+
+    assert record.num_transactions == nt
+    assert record.num_records == nr

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -1,3 +1,4 @@
+import string
 from datetime import date
 
 from hypothesis import given
@@ -13,12 +14,9 @@ def dates(min_value=date(1969, 1, 1), max_value=date(2068, 12, 31)):
     return st.dates(min_value=min_value, max_value=max_value)
 
 
-def digits(num_digits=10):
-    max_value = 10**num_digits - 1
-    return (
-        st.integers(min_value=0, max_value=max_value)
-        .map(lambda v: '{value:0{num_digits}}'.format(
-            num_digits=num_digits, value=v)))
+def digits(min_size=10, max_size=None):
+    max_size = max_size or min_size
+    return st.text(string.digits, min_size=min_size, max_size=max_size)
 
 
 @given(tn=digits(7), dt=digits(8), dr=digits(8))
@@ -153,7 +151,7 @@ def test_assignment_end_for_avtalegiro_agreements(nt, nr):
     tn=st.integers(min_value=0, max_value=9999999),
     nd=dates(),
     a=st.integers(min_value=0),
-    kid=digits(25),  # TODO Alternatively shorter with leading space padding
+    kid=digits(min_size=4, max_size=25),
     cid=digits(2),
     dc=st.integers(min_value=1, max_value=31),
     psn=st.integers(min_value=0, max_value=9),
@@ -196,7 +194,7 @@ def test_transaction_amount_item_1_for_ocr_giro_transactions(
     tn=st.integers(min_value=0, max_value=9999999),
     nd=dates(),
     a=st.integers(min_value=0),
-    kid=digits(25),  # TODO Alternatively shorter with leading space padding
+    kid=digits(min_size=4, max_size=25),
 )
 def test_transaction_amount_item_1_for_avtalegiro_payment_requests(
         tn, nd, a, kid):
@@ -322,7 +320,7 @@ def test_transaction_specification_for_avtalegiro_payment_request(
 
 @given(
     tn=st.integers(min_value=0, max_value=9999999),
-    kid=digits(25),  # TODO Alternatively shorter with leading space padding
+    kid=digits(min_size=4, max_size=25),
     n=st.booleans(),
 )
 def test_avtalegiro_agreement(tn, kid, n):

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -1,0 +1,64 @@
+from datetime import date
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+import netsgiro.records
+
+
+def dates(min_value=date(1969, 1, 1), max_value=date(2068, 12, 31)):
+    # The default min/max values are picked to match how Python converts
+    # two-digit years to four-digit years. If Nets has specified any other
+    # interpretation, the min/max here should be adjusted accordingly.
+    return st.dates(min_value=min_value, max_value=max_value)
+
+
+def digits(num_digits=10):
+    max_value = 10**num_digits - 1
+    return (
+        st.integers(min_value=0, max_value=max_value)
+        .map(lambda v: '{value:0{num_digits}}'.format(
+            num_digits=num_digits, value=v)))
+
+
+@given(tn=digits(7), dt=digits(8), dr=digits(8))
+def test_transmission_start(tn, dt, dr):
+    original = netsgiro.records.TransmissionStart(
+        service_code=netsgiro.ServiceCode.NONE,
+        transmission_number=tn,
+        data_transmitter=dt,
+        data_recipient=dr,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.TransmissionStart.from_string(ocr)
+
+    assert record.service_code == netsgiro.ServiceCode.NONE
+    assert record.transmission_number == tn
+    assert record.data_transmitter == dt
+    assert record.data_recipient == dr
+
+
+@given(
+    nt=st.integers(min_value=0),
+    nr=st.integers(min_value=0),
+    ta=st.integers(min_value=0),
+    nd=dates(),
+)
+def test_transmission_end(nt, nr, ta, nd):
+    original = netsgiro.records.TransmissionEnd(
+        service_code=netsgiro.ServiceCode.NONE,
+        num_transactions=nt,
+        num_records=nr,
+        total_amount=ta,
+        nets_date=nd,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.TransmissionEnd.from_string(ocr)
+
+    assert record.service_code == netsgiro.ServiceCode.NONE
+    assert record.num_transactions == nt
+    assert record.num_records == nr
+    assert record.total_amount == ta
+    assert record.nets_date == nd

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -217,3 +217,56 @@ def test_transaction_amount_item_1_for_avtalegiro_payment_requests(
     assert record.nets_date == nd
     assert record.amount == a
     assert record.kid == kid
+
+
+@given(
+    tn=st.integers(min_value=0, max_value=9999999),
+    pn=st.text(max_size=10),
+)
+def test_transaction_amount_item_2_for_avtalegiro_payment_request(tn, pn):
+    original = netsgiro.records.TransactionAmountItem2(
+        service_code=netsgiro.ServiceCode.AVTALEGIRO,
+        transaction_type=(
+            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
+        transaction_number=tn,
+        reference=None,
+        payer_name=pn,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.TransactionAmountItem2.from_string(ocr)
+
+    assert record.transaction_number == tn
+    assert record.payer_name == original.payer_name
+
+
+@given(
+    tn=st.integers(min_value=0, max_value=9999999),
+    ref=digits(9),
+    fn=digits(10),
+    bd=dates(),
+    da=digits(11),
+)
+def test_transaction_amount_item_2_for_ocr_giro_transactions(
+        tn, ref, fn, bd, da):
+    original = netsgiro.records.TransactionAmountItem2(
+        service_code=netsgiro.ServiceCode.OCR_GIRO,
+        transaction_type=(
+            netsgiro.TransactionType.FROM_GIRO_DEBITED_ACCOUNT),
+        transaction_number=tn,
+        reference=ref,
+
+        form_number=fn,
+        bank_date=bd,
+        debit_account=da,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.TransactionAmountItem2.from_string(ocr)
+
+    assert record.transaction_number == tn
+    assert record.form_number == fn
+    assert record.payer_name is None
+    assert record.reference == ref
+    assert record.bank_date == bd
+    assert record.debit_account == da

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -318,3 +318,28 @@ def test_transaction_specification_for_avtalegiro_payment_request(
     assert record.column_number == cn
     assert len(record.text) == 40
     assert record.text == original.text
+
+
+@given(
+    tn=st.integers(min_value=0, max_value=9999999),
+    kid=digits(25),  # TODO Alternatively shorter with leading space padding
+    n=st.booleans(),
+)
+def test_avtalegiro_agreement(tn, kid, n):
+    original = netsgiro.records.AvtaleGiroAgreement(
+        service_code=netsgiro.ServiceCode.AVTALEGIRO,
+        transaction_type=(
+            netsgiro.TransactionType.AVTALEGIRO_AGREEMENT),
+        transaction_number=tn,
+        registration_type=(
+            netsgiro.AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT),
+        kid=kid,
+        notify=n,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.AvtaleGiroAgreement.from_string(ocr)
+
+    assert record.transaction_number == tn
+    assert record.kid == kid
+    assert record.notify == n

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -290,3 +290,31 @@ def test_transaction_amount_item_3_for_ocr_giro_transactions(tn, text):
 
     assert record.transaction_number == tn
     assert record.text == original.text
+
+
+@given(
+    tn=st.integers(min_value=0, max_value=9999999),
+    ln=st.integers(min_value=1, max_value=42),
+    cn=st.integers(min_value=1, max_value=2),
+    text=st.text(min_size=40, max_size=40),
+)
+def test_transaction_specification_for_avtalegiro_payment_request(
+        tn, ln, cn, text):
+    original = netsgiro.records.TransactionSpecification(
+        service_code=netsgiro.ServiceCode.AVTALEGIRO,
+        transaction_type=(
+            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
+        transaction_number=tn,
+        line_number=ln,
+        column_number=cn,
+        text=text,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.TransactionSpecification.from_string(ocr)
+
+    assert record.transaction_number == tn
+    assert record.line_number == ln
+    assert record.column_number == cn
+    assert len(record.text) == 40
+    assert record.text == original.text

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -270,3 +270,23 @@ def test_transaction_amount_item_2_for_ocr_giro_transactions(
     assert record.reference == ref
     assert record.bank_date == bd
     assert record.debit_account == da
+
+
+@given(
+    tn=st.integers(min_value=0, max_value=9999999),
+    text=st.text(max_size=40),
+)
+def test_transaction_amount_item_3_for_ocr_giro_transactions(tn, text):
+    original = netsgiro.records.TransactionAmountItem3(
+        service_code=netsgiro.ServiceCode.OCR_GIRO,
+        transaction_type=(
+            netsgiro.TransactionType.PURCHASE_WITH_TEXT),
+        transaction_number=tn,
+        text=text,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.TransactionAmountItem3.from_string(ocr)
+
+    assert record.transaction_number == tn
+    assert record.text == original.text

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -62,3 +62,41 @@ def test_transmission_end(nt, nr, ta, nd):
     assert record.num_records == nr
     assert record.total_amount == ta
     assert record.nets_date == nd
+
+
+@given(an=digits(7), aa=digits(11), ai=digits(9))
+def test_assignment_start_for_avtalegiro_payment_requests(an, aa, ai):
+    original = netsgiro.records.AssignmentStart(
+        service_code=netsgiro.ServiceCode.AVTALEGIRO,
+        assignment_type=netsgiro.AssignmentType.TRANSACTIONS,
+        assignment_number=an,
+        assignment_account=aa,
+        agreement_id=ai,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.AssignmentStart.from_string(ocr)
+
+    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
+    assert record.assignment_type == netsgiro.AssignmentType.TRANSACTIONS
+    assert record.agreement_id == ai
+    assert record.assignment_number == an
+    assert record.assignment_account == aa
+
+
+@given(an=digits(7), aa=digits(11))
+def test_assignment_start_for_avtalegiro_agreements(an, aa):
+    original = netsgiro.records.AssignmentStart(
+        service_code=netsgiro.ServiceCode.AVTALEGIRO,
+        assignment_type=netsgiro.AssignmentType.AVTALEGIRO_AGREEMENTS,
+        assignment_number=an,
+        assignment_account=aa,
+        agreement_id=None,
+    )
+
+    ocr = original.to_ocr()
+    record = netsgiro.records.AssignmentStart.from_string(ocr)
+
+    assert record.agreement_id is None
+    assert record.assignment_number == an
+    assert record.assignment_account == aa

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ skip_missing_interpreters = true
 [testenv]
 usedevelop = true
 deps =
+    hypothesis
     pytest
     pytest-cov
 commands =


### PR DESCRIPTION
This PR adds a number of property based tests for the records API using the [Hypothesis](https://hypothesis.readthedocs.io/en/latest/) library.

This was mostly boring grunt work until I started testing records which included text fields. Here the new tests identified a number of issues that could lead to generation of invalid OCR output. The identified issues have already been fixed on the master branch.

A negative effect of this addition is that the test suite runtime is now up from 0.2s to 15.6s on my laptop. This is a natural effect of how Hypothesis works: For each test it tries a number of permutations (typically 200) of the input data in the hope of making the test fail, until it finds input data that causes a test failure or it gives up without any failures.