### PR TITLE
Add minimum `due_date` validation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
         id: cache-venv
         with:
           path: .venv
-          key: ${{ hashFiles('**/poetry.lock') }}-0
+          key: ${{ hashFiles('**/poetry.lock') }}-1
       - run: |
           python -m venv .venv
           source .venv/bin/activate

--- a/netsgiro/__init__.py
+++ b/netsgiro/__init__.py
@@ -7,8 +7,10 @@ __version__ = '1.3.0'
 from netsgiro.constants import *
 from netsgiro.enums import *
 from netsgiro.objects import *
+from netsgiro.utils import *
 
-from netsgiro import constants, enums, objects  # isort: skip
+# Must be placed last
+from netsgiro import constants, enums, objects  # noqa, isort: skip
 
 
-__all__ = constants.__all__ + enums.__all__ + objects.__all__
+__all__ = constants.__all__ + enums.__all__ + objects.__all__ + utils.__all__

--- a/netsgiro/objects.py
+++ b/netsgiro/objects.py
@@ -414,11 +414,7 @@ class Assignment:
         bank_notification=None,
     ) -> 'Transaction':
 
-        if isinstance(bank_notification, str):
-            text = bank_notification
-        else:
-            text = ''
-
+        text = bank_notification if isinstance(bank_notification, str) else ''
         number = self._next_transaction_number
         self._next_transaction_number += 1
 

--- a/netsgiro/objects.py
+++ b/netsgiro/objects.py
@@ -13,6 +13,8 @@ from netsgiro.validators import str_of_length
 
 if TYPE_CHECKING:
     from netsgiro.records import Record, TransactionRecord
+from netsgiro.records import Record
+from netsgiro.validators import str_of_length, validate_minimum_date
 
 __all__ = [
     'Transmission',
@@ -326,6 +328,7 @@ class Assignment:
         reference: Optional[str] = None,
         payer_name: Optional[str] = None,
         bank_notification: Union[bool, str] = False,
+        strict: bool = False,
     ) -> 'Transaction':
         """Add an AvtaleGiro payment request to the assignment.
 
@@ -339,6 +342,10 @@ class Assignment:
         assert (
             self.type == netsgiro.AssignmentType.TRANSACTIONS
         ), 'Can only add payment requests to transaction assignments'
+
+        if strict:
+            # Make sure we're not passing invalid due dates
+            validate_minimum_date(due_date)
 
         if bank_notification:
             transaction_type = (

--- a/netsgiro/utils.py
+++ b/netsgiro/utils.py
@@ -1,0 +1,29 @@
+from contextlib import suppress
+from datetime import date, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+__all__ = ['get_minimum_due_date']
+
+# Nets operates in the Norwegian timezone, so that's what we'll use
+OSLO_TZ = ZoneInfo('Europe/Oslo')
+
+
+def get_minimum_due_date(now: datetime) -> date:
+    """Return the minimum viable due date for a an ocrgiro created right now."""
+    today = now.date()
+
+    # 14:00 is the cut-off for sending in new transmissions;
+    # files sent after 14:00 are processed the following day.
+    delta = 5 if now.hour > 13 else 4
+
+    # Adjust for holidays, if the client has the optional dependency installed
+    with suppress(ImportError):
+        from holidays import country_holidays
+
+        delta += len(country_holidays('NO')[now : now + timedelta(days=delta)])
+
+    # File have to be received on weekdays to be processed the same day
+    if today.weekday() in [5, 6]:
+        delta += 7 - today.weekday()
+
+    return (now + timedelta(days=delta)).date()

--- a/netsgiro/utils.py
+++ b/netsgiro/utils.py
@@ -1,14 +1,22 @@
 from contextlib import suppress
-from datetime import date, datetime, timedelta
-from zoneinfo import ZoneInfo
+from datetime import timedelta
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import date, datetime
+
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
 
 __all__ = ['get_minimum_due_date']
 
 # Nets operates in the Norwegian timezone, so that's what we'll use
-OSLO_TZ = ZoneInfo('Europe/Oslo')
+OSLO_TZ = zoneinfo.ZoneInfo('Europe/Oslo')
 
 
-def get_minimum_due_date(now: datetime) -> date:
+def get_minimum_due_date(now: 'datetime') -> 'date':
     """Return the minimum viable due date for a an ocrgiro created right now."""
     today = now.date()
 

--- a/netsgiro/validators.py
+++ b/netsgiro/validators.py
@@ -1,6 +1,10 @@
 """Custom validators for :mod:`attrs`."""
+from datetime import date, datetime
+from typing import NoReturn
 
 from attr.validators import instance_of
+
+from netsgiro.utils import OSLO_TZ, get_minimum_due_date
 
 
 def str_of_length(length):
@@ -32,3 +36,13 @@ def str_of_max_length(length):
             )
 
     return validator
+
+
+def validate_minimum_date(value: date) -> NoReturn:
+    """Make sure payment request dates are gt the minimum allowed date."""
+    if value < get_minimum_due_date(now=datetime.now(tz=OSLO_TZ)):
+        raise ValueError(
+            'The minimum due date of a transaction is today + 4 calendar days.'
+            ' OCR files with due dates earlier than this will be rejected when'
+            ' submitted.'
+        )

--- a/poetry.lock
+++ b/poetry.lock
@@ -40,6 +40,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 pytz = ">=2015.7"
 
 [[package]]
+name = "backports.zoneinfo"
+version = "0.2.1"
+description = "Backport of the standard library zoneinfo module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+tzdata = ["tzdata"]
+
+[[package]]
 name = "build"
 version = "0.7.0"
 description = "A simple, correct PEP517 package builder"
@@ -165,7 +176,7 @@ testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-co
 
 [[package]]
 name = "hypothesis"
-version = "6.41.0"
+version = "6.43.0"
 description = "A library for property-based testing"
 category = "dev"
 optional = false
@@ -373,14 +384,14 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "pyparsing"
-version = "3.0.7"
-description = "Python parsing module"
+version = "3.0.8"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
 category = "dev"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["jinja2", "railroad-diagrams"]
+diagrams = ["railroad-diagrams", "jinja2"]
 
 [[package]]
 name = "pytest"
@@ -648,7 +659,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.14.0"
+version = "20.14.1"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -677,10 +688,13 @@ python-versions = ">=3.7"
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
+[extras]
+holidays = []
+
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "886cb861d226ffce5b600e57bf7a0463884f51672c4bce7d516671a3e1a7c00c"
+content-hash = "7d0da28b29e9d329ee5b92107a1b68ec01a21dd8c48ed7a27a917a333400ad06"
 
 [metadata.files]
 alabaster = [
@@ -698,6 +712,24 @@ attrs = [
 babel = [
     {file = "Babel-2.9.1-py2.py3-none-any.whl", hash = "sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9"},
     {file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"},
+]
+"backports.zoneinfo" = [
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
+    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
 ]
 build = [
     {file = "build-0.7.0-py3-none-any.whl", hash = "sha256:21b7ebbd1b22499c4dac536abc7606696ea4d909fd755e00f09f3c0f2c05e3c8"},
@@ -783,8 +815,8 @@ filelock = [
     {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
 ]
 hypothesis = [
-    {file = "hypothesis-6.41.0-py3-none-any.whl", hash = "sha256:ca931c5a6414f3f9636fdaf978a216ee9b5c4a6b4415adf628e9d5e5003dcd99"},
-    {file = "hypothesis-6.41.0.tar.gz", hash = "sha256:de48abb676fc76e4397cd002926e5747cef518570d132221244d27e1075c0bec"},
+    {file = "hypothesis-6.43.0-py3-none-any.whl", hash = "sha256:caf8410cdc849e88c7bcae0ceda13d0174d5a3e1df54d3351e08ae9793f5b147"},
+    {file = "hypothesis-6.43.0.tar.gz", hash = "sha256:2e0ed0e75900bc33216dcd0b0a44ab85dad26ab36412333ded40ea744df9a8ab"},
 ]
 identify = [
     {file = "identify-2.4.12-py2.py3-none-any.whl", hash = "sha256:5f06b14366bd1facb88b00540a1de05b69b310cbc2654db3c7e07fa3a4339323"},
@@ -889,8 +921,8 @@ pygments = [
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
 pyparsing = [
-    {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
-    {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
+    {file = "pyparsing-3.0.8-py3-none-any.whl", hash = "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"},
+    {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
 ]
 pytest = [
     {file = "pytest-7.1.1-py3-none-any.whl", hash = "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"},
@@ -1008,8 +1040,8 @@ urllib3 = [
     {file = "urllib3-1.22.tar.gz", hash = "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.14.0-py2.py3-none-any.whl", hash = "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66"},
-    {file = "virtualenv-20.14.0.tar.gz", hash = "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"},
+    {file = "virtualenv-20.14.1-py2.py3-none-any.whl", hash = "sha256:e617f16e25b42eb4f6e74096b9c9e37713cf10bf30168fb4a739f3fa8f898a3a"},
+    {file = "virtualenv-20.14.1.tar.gz", hash = "sha256:ef589a79795589aada0c1c5b319486797c03b67ac3984c48c669c0e4f50df3a5"},
 ]
 zipp = [
     {file = "zipp-3.8.0-py3-none-any.whl", hash = "sha256:c4f6e5bbf48e74f7a38e7cc5b0480ff42b0ae5178957d564d18932525d5cf099"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -122,6 +122,22 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "convertdate"
+version = "2.3.2"
+description = "Converts between Gregorian dates and other calendar systems.Calendars included: Baha'i, French Republican, Hebrew, Indian Civil, Islamic, ISO, Julian, Mayan and Persian."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pymeeus = ">=0.3.13,<=1"
+pytz = ">=2014.10"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+test = ["coverage"]
+
+[[package]]
 name = "coverage"
 version = "6.3.2"
 description = "Code coverage measurement for Python"
@@ -173,6 +189,28 @@ python-versions = ">=3.7"
 [package.extras]
 docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
 testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
+
+[[package]]
+name = "hijri-converter"
+version = "2.2.3"
+description = "Accurate Hijri-Gregorian dates converter based on the Umm al-Qura calendar"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "holidays"
+version = "0.13"
+description = "Generate and work with holidays in Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+convertdate = ">=2.3.0"
+hijri-converter = "*"
+korean-lunar-calendar = "*"
+python-dateutil = "*"
 
 [[package]]
 name = "hypothesis"
@@ -267,6 +305,14 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "korean-lunar-calendar"
+version = "0.2.1"
+description = "Korean Lunar Calendar"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "markupsafe"
@@ -383,6 +429,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "pymeeus"
+version = "0.5.11"
+description = "Python implementation of Jean Meeus astronomical routines"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyparsing"
 version = "3.0.8"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -444,6 +498,17 @@ pytest-forked = "*"
 psutil = ["psutil (>=3.0)"]
 setproctitle = ["setproctitle"]
 testing = ["filelock"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
 
 [[package]]
 name = "pytz"
@@ -694,7 +759,7 @@ holidays = []
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "7d0da28b29e9d329ee5b92107a1b68ec01a21dd8c48ed7a27a917a333400ad06"
+content-hash = "c446205b5ab882739b2d30e45e9bde60798785a403dfbe184c67f1ec59350bf7"
 
 [metadata.files]
 alabaster = [
@@ -755,6 +820,10 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+convertdate = [
+    {file = "convertdate-2.3.2-py3-none-any.whl", hash = "sha256:8f5e9efc2b71410d33217012c0a215f83463f765c94d5883bf656ce7a962b888"},
+    {file = "convertdate-2.3.2.tar.gz", hash = "sha256:57df962a6047534f1452c390ad48e3dc5c83052ad83ad6dd78d60ae22f99214c"},
+]
 coverage = [
     {file = "coverage-6.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b27d894748475fa858f9597c0ee1d4829f44683f3813633aaf94b19cb5453cf"},
     {file = "coverage-6.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37d1141ad6b2466a7b53a22e08fe76994c2d35a5b6b469590424a9953155afac"},
@@ -814,6 +883,14 @@ filelock = [
     {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
     {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
 ]
+hijri-converter = [
+    {file = "hijri-converter-2.2.3.tar.gz", hash = "sha256:e7149cececca647bf40689ec89bf593c7252b31d699ea587ad0bce91ba42d382"},
+    {file = "hijri_converter-2.2.3-py3-none-any.whl", hash = "sha256:50648d45a0b850c6d4a3aa7cf88ec4c03ee44740c339ee2bb021c7bb69791dcc"},
+]
+holidays = [
+    {file = "holidays-0.13-py3-none-any.whl", hash = "sha256:ca944d20762f027770ceae2f21d037f959c9b206afe92db97161ce78538c275e"},
+    {file = "holidays-0.13.tar.gz", hash = "sha256:c6f7c3ab8ada94806702da931d94d37cd61bcfa92cb4d39d351b6a9c5210675c"},
+]
 hypothesis = [
     {file = "hypothesis-6.43.0-py3-none-any.whl", hash = "sha256:caf8410cdc849e88c7bcae0ceda13d0174d5a3e1df54d3351e08ae9793f5b147"},
     {file = "hypothesis-6.43.0.tar.gz", hash = "sha256:2e0ed0e75900bc33216dcd0b0a44ab85dad26ab36412333ded40ea744df9a8ab"},
@@ -841,6 +918,10 @@ iniconfig = [
 jinja2 = [
     {file = "Jinja2-3.1.1-py3-none-any.whl", hash = "sha256:539835f51a74a69f41b848a9645dbdc35b4f20a3b601e2d9a7e22947b15ff119"},
     {file = "Jinja2-3.1.1.tar.gz", hash = "sha256:640bed4bb501cbd17194b3cace1dc2126f5b619cf068a726b98192a0fde74ae9"},
+]
+korean-lunar-calendar = [
+    {file = "korean_lunar_calendar-0.2.1-py3-none-any.whl", hash = "sha256:a619ea88610129019267467b85cc9faf0fab6e1694b2e782d1aeb610cdd382d5"},
+    {file = "korean_lunar_calendar-0.2.1.tar.gz", hash = "sha256:12ce54b1392ed45a82dc6cea85ee5f7e33630556e82488f57e37a22482c8275d"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
@@ -920,6 +1001,9 @@ pygments = [
     {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
+pymeeus = [
+    {file = "PyMeeus-0.5.11.tar.gz", hash = "sha256:bb9d670818d8b0594317b48a7dadea02a0594e5344263bf2054e1a011c8fed55"},
+]
 pyparsing = [
     {file = "pyparsing-3.0.8-py3-none-any.whl", hash = "sha256:ef7b523f6356f763771559412c0d7134753f037822dad1b16945b7b846f7ad06"},
     {file = "pyparsing-3.0.8.tar.gz", hash = "sha256:7bf433498c016c4314268d95df76c81b842a4cb2b276fa3312cfb1e1d85f6954"},
@@ -935,6 +1019,10 @@ pytest-forked = [
 pytest-xdist = [
     {file = "pytest-xdist-2.5.0.tar.gz", hash = "sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf"},
     {file = "pytest_xdist-2.5.0-py3-none-any.whl", hash = "sha256:6fe5c74fec98906deb8f2d2b616b5c782022744978e7bd4695d39c8f42d0ce65"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
     {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,9 @@ classifiers=[
 python = ">=3.7"
 attrs = ">=17.4"
 
+# Backports
+"backports.zoneinfo" = { version="^0.2.1", python="<3.9" }
+
 [tool.poetry.extras]
 # Holidays can be installed to enable holiday-adjustments
 # in minimum due-date validation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,11 @@ classifiers=[
 python = ">=3.7"
 attrs = ">=17.4"
 
+[tool.poetry.extras]
+# Holidays can be installed to enable holiday-adjustments
+# in minimum due-date validation.
+holidays = ['holidays']
+
 [tool.poetry.dev-dependencies]
 check-manifest = "*"
 hypothesis = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ coverage = [
     { extras = ["toml"], version = "^6", python = "3.10" },
     { version = "^5 || ^6", python = ">=3.6!=3.10" },
 ]
+holidays = "^0.13"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,75 @@
+from datetime import datetime, timedelta
+
+import holidays
+
+from netsgiro.utils import OSLO_TZ, get_minimum_due_date
+
+monday = datetime(2022, 3, 28, 13, 59, tzinfo=OSLO_TZ)
+
+
+def test_minimum_due_date_before_cutoff():
+    """
+    Files generated before 14:00 Norwegian time should be
+    adjusted by 4 days, minimum.
+    """
+    assert get_minimum_due_date(monday) == (monday + timedelta(days=4)).date()
+
+
+monday_after_cutoff = datetime(2022, 4, 1, 14, 1, tzinfo=OSLO_TZ)
+
+
+def test_minimum_due_date_after_cutoff():
+    """
+    Because files sent in after 14:00 are processed the next day, files
+    generated after 14:00 Norwegian time should be adjusted by 5 days.
+    """
+    assert (
+        get_minimum_due_date(monday_after_cutoff)
+        == (monday_after_cutoff + timedelta(days=5)).date()
+    )
+
+
+day_before_easter = datetime(2022, 4, 13, 13, 59, tzinfo=OSLO_TZ)
+
+
+def test_minimum_due_date_with_holidays_before_cutoff():
+    """
+    There are 2 holidays in the span 13-17th of April 2022,
+    so we expect the function to adjust the timedelta by 2 days.
+    """
+    assert (
+        get_minimum_due_date(day_before_easter)
+        == (day_before_easter + timedelta(days=6)).date()
+    )
+
+
+day_before_easter_after_cutoff = datetime(2022, 4, 13, 23, 59, tzinfo=OSLO_TZ)
+
+
+def test_minimum_due_date_with_holidays_after_cutoff():
+    """
+    If we send in the file after the cut-off, number of
+    holidays is upped to 3, so we expect 2 more days of offsetting.
+    """
+    assert (
+        get_minimum_due_date(day_before_easter_after_cutoff)
+        == (day_before_easter_after_cutoff + timedelta(days=8)).date()
+    )
+
+
+friday = datetime(2022, 4, 1, 23, 59, tzinfo=OSLO_TZ)
+
+
+def test_minimum_due_date_with_now_being_a_saturday():
+    assert get_minimum_due_date(friday) == (friday + timedelta(days=5)).date()
+
+
+def test_minimum_due_date_without_holiday_dependency():
+    """
+    Make sure an ImportError from a missing dependency isn't propagated.
+    """
+    import sys
+
+    sys.modules['holidays'] = None
+    assert get_minimum_due_date(monday) == (monday + timedelta(days=4)).date()
+    sys.modules['holidays'] = holidays


### PR DESCRIPTION
PR adds a new feature to the library: **minimum payment request date validation**.

There is a hard requirement for OCR-files to be processed 4 calendar days ahead of the transaction date of a transaction. 

Adding validation like we're doing here won't make it impossible to mess this up, but we're removing guaranteed mistakes.

### Notes

- I'm not super familiar with the netsgiro internals, so I might have added this to the wrong class, or in a suboptimal way. Perhaps this should be added in some other way.
- I purposely added this as an exported utility function, because we want to re-use this in other projects.

### To do

If the PR is accepted, I think we still need to add docs on the `holidays` optional dependency. What it does and how to install it.

### Reference

<img width="1069" alt="image" src="https://user-images.githubusercontent.com/25310870/161259580-db4e1804-e61b-4430-92ea-50c3935dfaeb.png">