### PR TITLE
Add max `due_date` validation

### DIFF
--- a/netsgiro/objects.py
+++ b/netsgiro/objects.py
@@ -14,7 +14,7 @@ from netsgiro.validators import str_of_length
 if TYPE_CHECKING:
     from netsgiro.records import Record, TransactionRecord
 from netsgiro.records import Record
-from netsgiro.validators import str_of_length, validate_minimum_date
+from netsgiro.validators import str_of_length, validate_due_date
 
 __all__ = [
     'Transmission',
@@ -345,7 +345,7 @@ class Assignment:
 
         if strict:
             # Make sure we're not passing invalid due dates
-            validate_minimum_date(due_date)
+            validate_due_date(due_date)
 
         if bank_notification:
             transaction_type = (

--- a/netsgiro/validators.py
+++ b/netsgiro/validators.py
@@ -1,5 +1,5 @@
 """Custom validators for :mod:`attrs`."""
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import NoReturn
 
 from attr.validators import instance_of
@@ -38,11 +38,20 @@ def str_of_max_length(length):
     return validator
 
 
-def validate_minimum_date(value: date) -> NoReturn:
+def validate_due_date(value: date) -> NoReturn:
     """Make sure payment request dates are gt the minimum allowed date."""
-    if value < get_minimum_due_date(now=datetime.now(tz=OSLO_TZ)):
+    now = datetime.now(tz=OSLO_TZ)
+
+    if value < get_minimum_due_date(now=now):
         raise ValueError(
             'The minimum due date of a transaction is today + 4 calendar days.'
             ' OCR files with due dates earlier than this will be rejected when'
+            ' submitted.'
+        )
+
+    if value > (now + timedelta(days=365)).date():
+        raise ValueError(
+            'The maximum due date of a transaction is 12 months into the future.'
+            ' OCR files with due dates later than this will be rejected when'
             ' submitted.'
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timedelta
 
 import holidays
+import pytest
 
 from netsgiro.utils import OSLO_TZ, get_minimum_due_date
+from netsgiro.validators import validate_due_date
 
 monday = datetime(2022, 3, 28, 13, 59, tzinfo=OSLO_TZ)
 
@@ -73,3 +75,12 @@ def test_minimum_due_date_without_holiday_dependency():
     sys.modules['holidays'] = None
     assert get_minimum_due_date(monday) == (monday + timedelta(days=4)).date()
     sys.modules['holidays'] = holidays
+
+
+def test_validate_due_date():
+    with pytest.raises(ValueError, match='The minimum due date of a transaction'):
+        validate_due_date(datetime.now().date())
+
+    with pytest.raises(ValueError, match='The maximum due date of a transaction'):
+        validate_due_date( (datetime.now() + timedelta(days=366)).date() )
+


### PR DESCRIPTION
Adjusts the due date validator to also account for maximum due date.

### Reference

<img width="651" alt="image" src="https://user-images.githubusercontent.com/25310870/161277977-9706354f-63e8-4aad-88a4-0049c87b47d9.png">
