### PR TITLE
fix: Convert to f-string to fix payer name edge case

### DIFF
--- a/netsgiro/records.py
+++ b/netsgiro/records.py
@@ -17,7 +17,6 @@ from netsgiro.converters import (
 )
 from netsgiro.validators import str_of_length, str_of_max_length
 
-
 __all__ = [
     'TransmissionStart',
     'TransmissionEnd',
@@ -144,7 +143,8 @@ class TransmissionStart(Record):
             'NY000010'
             f'{self.data_transmitter:8}'
             f'{self.transmission_number:7}'
-            f'{self.data_recipient:8}' + ('0' * 49)
+            f'{self.data_recipient:8}'
+            + ('0' * 49)
         )
 
 
@@ -186,7 +186,8 @@ class TransmissionEnd(Record):
             f'{self.num_transactions:08d}'
             f'{self.num_records:08d}'
             f'{self.total_amount:017d}'
-            f'{self.nets_date:%d%m%y}' + ('0' * 33)
+            f'{self.nets_date:%d%m%y}'
+            + ('0' * 33)
         )
 
 
@@ -264,13 +265,10 @@ class AssignmentStart(Record):
     def to_ocr(self) -> str:
         """Get record as OCR string."""
         return (
-                'NY'
-                f'{self.service_code:02d}'
-                f'{self.assignment_type:02d}'
-                '20'
-                + (self.agreement_id and f'{self.agreement_id:9}' or ('0' * 9))
-                + f'{self.assignment_number:7}'
-                  f'{self.assignment_account:11}' + ('0' * 45)
+            f'NY{self.service_code:02d}{self.assignment_type:02d}20'
+            + (self.agreement_id and f'{self.agreement_id:9}' or ('0' * 9))
+            + f'{self.assignment_number:7}{self.assignment_account:11}'
+            + ('0' * 45)
         )
 
 
@@ -367,9 +365,7 @@ class AssignmentEnd(Record):
         elif self.service_code == netsgiro.ServiceCode.AVTALEGIRO:
             return self.nets_date_1
         else:
-            raise ValueError(
-                f'Unhandled service code: {self.service_code}'
-            )
+            raise ValueError(f'Unhandled service code: {self.service_code}')
 
     @property
     def nets_date_latest(self):
@@ -380,24 +376,22 @@ class AssignmentEnd(Record):
         elif self.service_code == netsgiro.ServiceCode.AVTALEGIRO:
             return self.nets_date_2
         else:
-            raise ValueError(
-                f'Unhandled service code: {self.service_code}'
-            )
+            raise ValueError(f'Unhandled service code: {self.service_code}')
 
     def to_ocr(self) -> str:
         """Get record as OCR string."""
         return (
-                'NY'
-                f'{self.service_code:02d}'
-                f'{self.assignment_type:02d}'
-                '88'
-                f'{self.num_transactions:08d}'
-                f'{self.num_records:08d}'
-                + (self.total_amount and f'{self.total_amount:017d}' or ('0' * 17))
-                + (self.nets_date_1 and f'{self.nets_date_1:%d%m%y}' or ('0' * 6))
-                + (self.nets_date_2 and f'{self.nets_date_2:%d%m%y}' or ('0' * 6))
-                + (self.nets_date_3 and f'{self.nets_date_3:%d%m%y}' or ('0' * 6))
-                + ('0' * 21)
+            'NY'
+            f'{self.service_code:02d}'
+            f'{self.assignment_type:02d}'
+            '88'
+            f'{self.num_transactions:08d}'
+            f'{self.num_records:08d}'
+            + (self.total_amount and f'{self.total_amount:017d}' or ('0' * 17))
+            + (self.nets_date_1 and f'{self.nets_date_1:%d%m%y}' or ('0' * 6))
+            + (self.nets_date_2 and f'{self.nets_date_2:%d%m%y}' or ('0' * 6))
+            + (self.nets_date_3 and f'{self.nets_date_3:%d%m%y}' or ('0' * 6))
+            + ('0' * 21)
         )
 
 
@@ -495,13 +489,15 @@ class TransactionAmountItem1(TransactionRecord):
             ocr_giro_fields = ' ' * 11
 
         return (
-                'NY'
-                f'{self.service_code:02d}'
-                f'{self.transaction_type:02d}'
-                '30'
-                f'{self.transaction_number:07d}'
-                f'{self.nets_date:%d%m%y}' + ocr_giro_fields + f'{self.amount:017d}'
-                                                              f'{self.kid:>25}' + ('0' * 6)
+            'NY'
+            f'{self.service_code:02d}'
+            f'{self.transaction_type:02d}'
+            '30'
+            f'{self.transaction_number:07d}'
+            f'{self.nets_date:%d%m%y}'
+            + ocr_giro_fields
+            + f'{self.amount:017d}{self.kid:>25}'
+            + ('0' * 6)
         )
 
 
@@ -583,23 +579,19 @@ class TransactionAmountItem2(TransactionRecord):
         )
         if self.service_code == netsgiro.ServiceCode.OCR_GIRO:
             service_fields = (
-                    f'{self.form_number:10}'
-                    + (self.reference and f'{self.reference:9}' or (' ' * 9))
-                    + (self._filler and f'{self._filler:7}' or ('0' * 7))
-                    + (self.bank_date and f'{self.bank_date:%d%m%y}' or '0' * 6)
-                    + f'{self.debit_account:11}'
-                    + ('0' * 22)
+                f'{self.form_number:10}'
+                + (self.reference and f'{self.reference:9}' or (' ' * 9))
+                + (self._filler and f'{self._filler:7}' or ('0' * 7))
+                + (self.bank_date and f'{self.bank_date:%d%m%y}' or '0' * 6)
+                + f'{self.debit_account:11}'
+                + ('0' * 22)
             )
         elif self.service_code == netsgiro.ServiceCode.AVTALEGIRO:
             service_fields = (
-                    (
-                            self.payer_name
-                            and f'{self.payer_name[:10]:10}'
-                            or (' ' * 10)
-                    )
-                    + (' ' * 25)
-                    + (self.reference and f'{self.reference:25}' or (' ' * 25))
-                    + ('0' * 5)
+                (self.payer_name and f'{self.payer_name[:10]:10}' or (' ' * 10))
+                + (' ' * 25)
+                + (self.reference and f'{self.reference:25}' or (' ' * 25))
+                + ('0' * 5)
             )
         else:
             service_fields = ' ' * 35
@@ -641,12 +633,9 @@ class TransactionAmountItem3(TransactionRecord):
     def to_ocr(self) -> str:
         """Get record as OCR string."""
         return (
-                'NY09'
-                f'{self.transaction_type:02d}'
-                '32'
-                f'{self.transaction_number:07d}'
-                + (self.text and f'{self.text:40}' or (' ' * 40))
-                + ('0' * 25)
+            f'NY09{self.transaction_type:02d}32{self.transaction_number:07d}'
+            + (self.text and f'{self.text:40}' or (' ' * 40))
+            + ('0' * 25)
         )
 
 
@@ -766,7 +755,8 @@ class TransactionSpecification(TransactionRecord):
             '4'
             f'{self.line_number:03d}'
             f'{self.column_number:01d}'
-            f'{self.text:40}' + ('0' * 20)
+            f'{self.text:40}'
+            + ('0' * 20)
         )
 
 
@@ -812,7 +802,9 @@ class AvtaleGiroAgreement(TransactionRecord):
             'NY219470'
             f'{self.transaction_number:07d}'
             f'{self.registration_type:01d}'
-            f'{self.kid:>25}' + (self.notify and 'J' or 'N') + ('0' * 38)
+            f'{self.kid:>25}'
+            + (self.notify and 'J' or 'N')
+            + ('0' * 38)
         ).format(self=self)
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -111,6 +111,22 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "convertdate"
+version = "2.3.2"
+description = "Converts between Gregorian dates and other calendar systems.Calendars included: Baha'i, French Republican, Hebrew, Indian Civil, Islamic, ISO, Julian, Mayan and Persian."
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+pymeeus = ">=0.3.13,<=1"
+pytz = ">=2014.10"
+
+[package.extras]
+docs = ["sphinx", "sphinx-rtd-theme"]
+test = ["coverage"]
+
+[[package]]
 name = "distlib"
 version = "0.3.4"
 description = "Distribution utilities"
@@ -148,6 +164,28 @@ python-versions = ">=3.7"
 [package.extras]
 docs = ["furo (>=2021.8.17b43)", "sphinx (>=4.1)", "sphinx-autodoc-typehints (>=1.12)"]
 testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-cov", "pytest-timeout (>=1.4.2)"]
+
+[[package]]
+name = "hijri-converter"
+version = "2.2.3"
+description = "Accurate Hijri-Gregorian dates converter based on the Umm al-Qura calendar"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "holidays"
+version = "0.13"
+description = "Generate and work with holidays in Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+convertdate = ">=2.3.0"
+hijri-converter = "*"
+korean-lunar-calendar = "*"
+python-dateutil = "*"
 
 [[package]]
 name = "hypothesis"
@@ -242,6 +280,14 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "korean-lunar-calendar"
+version = "0.2.1"
+description = "Korean Lunar Calendar"
+category = "dev"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "markupsafe"
@@ -358,6 +404,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "pymeeus"
+version = "0.5.11"
+description = "Python implementation of Jean Meeus astronomical routines"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyparsing"
 version = "3.0.7"
 description = "Python parsing module"
@@ -419,6 +473,17 @@ pytest-forked = "*"
 psutil = ["psutil (>=3.0)"]
 setproctitle = ["setproctitle"]
 testing = ["filelock"]
+
+[[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
 
 [[package]]
 name = "pytz"
@@ -669,7 +734,7 @@ holidays = []
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7"
-content-hash = "3d7ec812c5089844c546c55e620a7c403114fd7517aaa1058b059bae9d84780d"
+content-hash = "cdeaf3874dc9788fa6304eefb807cc7167b38debdd139adf23d9849c5f0d5eab"
 
 [metadata.files]
 alabaster = [
@@ -712,6 +777,10 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
+convertdate = [
+    {file = "convertdate-2.3.2-py3-none-any.whl", hash = "sha256:8f5e9efc2b71410d33217012c0a215f83463f765c94d5883bf656ce7a962b888"},
+    {file = "convertdate-2.3.2.tar.gz", hash = "sha256:57df962a6047534f1452c390ad48e3dc5c83052ad83ad6dd78d60ae22f99214c"},
+]
 distlib = [
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
@@ -727,6 +796,14 @@ execnet = [
 filelock = [
     {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
     {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
+]
+hijri-converter = [
+    {file = "hijri-converter-2.2.3.tar.gz", hash = "sha256:e7149cececca647bf40689ec89bf593c7252b31d699ea587ad0bce91ba42d382"},
+    {file = "hijri_converter-2.2.3-py3-none-any.whl", hash = "sha256:50648d45a0b850c6d4a3aa7cf88ec4c03ee44740c339ee2bb021c7bb69791dcc"},
+]
+holidays = [
+    {file = "holidays-0.13-py3-none-any.whl", hash = "sha256:ca944d20762f027770ceae2f21d037f959c9b206afe92db97161ce78538c275e"},
+    {file = "holidays-0.13.tar.gz", hash = "sha256:c6f7c3ab8ada94806702da931d94d37cd61bcfa92cb4d39d351b6a9c5210675c"},
 ]
 hypothesis = [
     {file = "hypothesis-6.37.2-py3-none-any.whl", hash = "sha256:1c1777ccd3074fcca768d7594a284a41501c99843089d37e3235d38319e3f217"},
@@ -755,6 +832,10 @@ iniconfig = [
 jinja2 = [
     {file = "Jinja2-3.0.3-py3-none-any.whl", hash = "sha256:077ce6014f7b40d03b47d1f1ca4b0fc8328a692bd284016f806ed0eaca390ad8"},
     {file = "Jinja2-3.0.3.tar.gz", hash = "sha256:611bb273cd68f3b993fabdc4064fc858c5b47a973cb5aa7999ec1ba405c87cd7"},
+]
+korean-lunar-calendar = [
+    {file = "korean_lunar_calendar-0.2.1-py3-none-any.whl", hash = "sha256:a619ea88610129019267467b85cc9faf0fab6e1694b2e782d1aeb610cdd382d5"},
+    {file = "korean_lunar_calendar-0.2.1.tar.gz", hash = "sha256:12ce54b1392ed45a82dc6cea85ee5f7e33630556e82488f57e37a22482c8275d"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:3028252424c72b2602a323f70fbf50aa80a5d3aa616ea6add4ba21ae9cc9da4c"},
@@ -834,6 +915,9 @@ pygments = [
     {file = "Pygments-2.11.2-py3-none-any.whl", hash = "sha256:44238f1b60a76d78fc8ca0528ee429702aae011c265fe6a8dd8b63049ae41c65"},
     {file = "Pygments-2.11.2.tar.gz", hash = "sha256:4e426f72023d88d03b2fa258de560726ce890ff3b630f88c21cbb8b2503b8c6a"},
 ]
+pymeeus = [
+    {file = "PyMeeus-0.5.11.tar.gz", hash = "sha256:bb9d670818d8b0594317b48a7dadea02a0594e5344263bf2054e1a011c8fed55"},
+]
 pyparsing = [
     {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
     {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
@@ -849,6 +933,10 @@ pytest-forked = [
 pytest-xdist = [
     {file = "pytest-xdist-2.5.0.tar.gz", hash = "sha256:4580deca3ff04ddb2ac53eba39d76cb5dd5edeac050cb6fbc768b0dd712b4edf"},
     {file = "pytest_xdist-2.5.0-py3-none-any.whl", hash = "sha256:6fe5c74fec98906deb8f2d2b616b5c782022744978e7bd4695d39c8f42d0ce65"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ pytest-xdist = "*"
 Sphinx = "*"
 sphinx-rtd-theme = "*"
 pre-commit = "^2.17.0"
+holidays = "^0.13"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
When { or } is passed as the payer name,
to_ocr methods break. Converting from
`.format` calls to f-strings resolves the issue