### PR TITLE
Update line length

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,9 +35,7 @@ todo_include_todos = False
 # -- Options for HTML output ----------------------------------------------
 
 html_theme = 'sphinx_rtd_theme'
-html_theme_options = {
-    'canonical_url': 'https://netsgiro.readthedocs.io/en/latest/'
-}
+html_theme_options = {'canonical_url': 'https://netsgiro.readthedocs.io/en/latest/'}
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_static_path = ['_static']
 
@@ -56,9 +54,7 @@ latex_elements = {
     # 'figure_align': 'htbp',
 }
 
-latex_documents = [
-    (master_doc, 'netsgiro.tex', 'netsgiro documentation', 'Otovo AS', 'manual')
-]
+latex_documents = [(master_doc, 'netsgiro.tex', 'netsgiro documentation', 'Otovo AS', 'manual')]
 
 
 # -- Options for doctest extension ----------------------------------------

--- a/netsgiro/__init__.py
+++ b/netsgiro/__init__.py
@@ -1,8 +1,6 @@
 """File parsers for Nets AvtaleGiro and OCR Giro files."""
 
-
-__version__ = '1.3.0'
-
+from typing import List
 
 from netsgiro.constants import *
 from netsgiro.enums import *
@@ -10,5 +8,6 @@ from netsgiro.objects import *
 
 from netsgiro import constants, enums, objects  # isort: skip
 
+__version__ = '1.3.0'
 
-__all__ = constants.__all__ + enums.__all__ + objects.__all__
+__all__: List[str] = constants.__all__ + enums.__all__ + objects.__all__

--- a/netsgiro/converters.py
+++ b/netsgiro/converters.py
@@ -4,9 +4,7 @@ from typing import Any, Callable, Optional, TypeVar
 T = TypeVar('T')
 
 
-def value_or_none(
-    converter: Callable[[Any], T]
-) -> Callable[[Any], Optional[T]]:
+def value_or_none(converter: Callable[[Any], T]) -> Callable[[Any], Optional[T]]:
     """Make converter that returns value or ``None``.
 
     ``converter`` is called to further convert non-``None`` values.
@@ -17,9 +15,7 @@ def value_or_none(
     return lambda value: None if value is None else converter(value)
 
 
-def truthy_or_none(
-    converter: Callable[[Any], T]
-) -> Callable[[Any], Optional[T]]:
+def truthy_or_none(converter: Callable[[Any], T]) -> Callable[[Any], Optional[T]]:
     """Make converter that returns a truthy value or ``None``.
 
     ``converter`` is called to further convert non-``None`` values.
@@ -27,9 +23,7 @@ def truthy_or_none(
     return lambda value: converter(value) if value else None
 
 
-def stripped_spaces_around(
-    converter: Callable[[Any], T]
-) -> Callable[[Any], Optional[T]]:
+def stripped_spaces_around(converter: Callable[[Any], T]) -> Callable[[Any], Optional[T]]:
     """Make converter that strips leading and trailing spaces.
 
     ``converter`` is called to further convert non-``None`` values.
@@ -37,29 +31,17 @@ def stripped_spaces_around(
     return lambda value: None if value is None else converter(value.strip())
 
 
-def stripped_newlines(
-    converter: Callable[[Any], T]
-) -> Callable[[Any], Optional[T]]:
+def stripped_newlines(converter: Callable[[Any], T]) -> Callable[[Any], Optional[T]]:
     """Make converter that returns a string stripped of newlines or ``None``.
 
     ``converter`` is called to further convert non-``None`` values.
     """
-    return (
-        lambda value: None
-        if value is None
-        else converter(value.replace('\r', '').replace('\n', ''))
-    )
+    return lambda value: converter(value.replace('\r', '').replace('\n', ''))
 
 
-def fixed_len_str(
-    length: int, converter: Callable[[Any], T]
-) -> Callable[[Any], Optional[T]]:
+def fixed_len_str(length: int, converter: Callable[[Any], T]) -> Callable[[Any], Optional[T]]:
     """Make converter that pads a string to the given ``length`` or ``None``.
 
-    ``converter`` is called to further converti non-``None`` values.
+    ``converter`` is called to further convert non-``None`` values.
     """
-    return (
-        lambda value: None
-        if value is None
-        else converter('{value:{length}}'.format(value=value, length=length))
-    )
+    return lambda value: converter('{value:{length}}'.format(value=value, length=length))

--- a/netsgiro/validators.py
+++ b/netsgiro/validators.py
@@ -4,33 +4,28 @@ from typing import Any, Callable
 from attr import Attribute
 from attr.validators import instance_of
 
-_C = Callable[[object, Attribute, Any], None]
+C = Callable[[object, Attribute, Any], None]
 
 
-def str_of_length(length: int) -> _C:
+def str_of_length(length: int) -> C:
     """Validate that the value is a string of the given length."""
 
     def validator(instance: object, attribute: Attribute, value: Any) -> None:
         instance_of(str)(instance, attribute, value)
         if len(value) != length:
-            raise ValueError(
-                '{0.name} must be exactly {1} chars, got {2!r}'.format(
-                    attribute, length, value
-                )
-            )
+            raise ValueError(f'{attribute.name} must be exactly {length} chars, got {value!r}')
 
     return validator
 
 
-def str_of_max_length(length: int) -> _C:
+def str_of_max_length(length: int) -> C:
     """Validate that the value is a string with a max length."""
 
     def validator(instance: object, attribute: Attribute, value: Any) -> None:
         instance_of(str)(instance, attribute, value)
         if len(value) > length:
             raise ValueError(
-                '{0.name} must be at most {1} chars, '
-                'got {2!r} which is {3} chars'.format(
+                '{0.name} must be at most {1} chars, got {2!r} which is {3} chars'.format(
                     attribute, length, value, len(value)
                 )
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,13 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 quiet = true
-line-length = 80
+line-length = 100
 skip-string-normalization = true
 preview = true
 
 [tool.isort]
 profile = "black"
-line_length = 80
+line_length = 100
 
 [tool.coverage.run]
 source = ['netsgiro']

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ exclude =
     __pycache__,
     tests/*
 max-complexity = 15
-max-line-length = 80
+max-line-length = 100
 type-checking-exempt-modules = typing
 enable-extensions = TC, TC2
 
@@ -34,6 +34,7 @@ warn_return_any = True
 show_error_codes = True
 ignore_missing_imports = True
 warn_unused_ignores = False
+disallow_any_generics = False
 
 [mypy-tests.*]
-disallow_untyped_defs = False
+ignore_errors = True

--- a/tests/test_object_parsing.py
+++ b/tests/test_object_parsing.py
@@ -28,9 +28,7 @@ def test_parse_agreements(agreements_data):
 
     assert isinstance(agreement_1, netsgiro.Agreement)
     assert agreement_1.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert agreement_1.TRANSACTION_TYPE == (
-        netsgiro.TransactionType.AVTALEGIRO_AGREEMENT
-    )
+    assert agreement_1.TRANSACTION_TYPE == (netsgiro.TransactionType.AVTALEGIRO_AGREEMENT)
     assert agreement_1.number == 1
 
     assert agreement_1.registration_type == (
@@ -43,9 +41,7 @@ def test_parse_agreements(agreements_data):
 
     assert isinstance(agreement_2, netsgiro.Agreement)
     assert agreement_2.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert agreement_2.TRANSACTION_TYPE == (
-        netsgiro.TransactionType.AVTALEGIRO_AGREEMENT
-    )
+    assert agreement_2.TRANSACTION_TYPE == (netsgiro.TransactionType.AVTALEGIRO_AGREEMENT)
     assert agreement_2.number == 2
 
     assert agreement_2.registration_type == (
@@ -79,9 +75,7 @@ def test_parse_payment_request(payment_request_data):
 
     assert isinstance(transaction, netsgiro.PaymentRequest)
     assert transaction.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert transaction.type == (
-        netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-    )
+    assert transaction.type == (netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION)
     assert transaction.number == 1
     assert transaction.date == date(2004, 6, 17)
     assert transaction.amount == Decimal('1.00')
@@ -90,8 +84,7 @@ def test_parse_payment_request(payment_request_data):
     assert transaction.reference is None
     assert (
         transaction.text
-        == ' Gjelder Faktura: 168837  Dato: 19/03/04'
-        '                  ForfallsDato: 17/06/04\n'
+        == ' Gjelder Faktura: 168837  Dato: 19/03/04                  ForfallsDato: 17/06/04\n'
     )
 
     # Specific to AvtaleGiro

--- a/tests/test_record_parsing.py
+++ b/tests/test_record_parsing.py
@@ -1,19 +1,35 @@
 from datetime import date
+from typing import List
 
 import pytest
 
-import netsgiro
-import netsgiro.records
+from netsgiro import (
+    AssignmentType,
+    AvtaleGiroRegistrationType,
+    RecordType,
+    ServiceCode,
+    TransactionType,
+)
+from netsgiro.records import (
+    AssignmentEnd,
+    AssignmentStart,
+    AvtaleGiroAgreement,
+    TransactionAmountItem1,
+    TransactionAmountItem2,
+    TransactionAmountItem3,
+    TransactionSpecification,
+    TransmissionEnd,
+    TransmissionStart,
+)
 
 
 def test_transmission_start():
-    record = netsgiro.records.TransmissionStart.from_string(
-        'NY00001055555555100008100008080000000000'
-        '0000000000000000000000000000000000000000'
+    record = TransmissionStart.from_string(
+        'NY000010555555551000081000080800000000000000000000000000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.NONE
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSMISSION_START
+    assert record.service_code == ServiceCode.NONE
+    assert record.RECORD_TYPE == RecordType.TRANSMISSION_START
 
     assert record.data_transmitter == '55555555'
     assert record.transmission_number == '1000081'
@@ -27,17 +43,16 @@ def test_transmission_start_fails_when_invalid_format():
         ValueError,
         match=f'{line!r} did not match TransmissionStart record format',
     ):
-        netsgiro.records.TransmissionStart.from_string(line)
+        TransmissionStart.from_string(line)
 
 
 def test_transmission_end():
-    record = netsgiro.records.TransmissionEnd.from_string(
-        'NY00008900000006000000220000000000000060'
-        '0170604000000000000000000000000000000000'
+    record = TransmissionEnd.from_string(
+        'NY000089000000060000002200000000000000600170604000000000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.NONE
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSMISSION_END
+    assert record.service_code == ServiceCode.NONE
+    assert record.RECORD_TYPE == RecordType.TRANSMISSION_END
 
     assert record.num_transactions == 6
     assert record.num_records == 22
@@ -46,15 +61,14 @@ def test_transmission_end():
 
 
 def test_assignment_start_for_avtalegiro_payment_requests():
-    record = netsgiro.records.AssignmentStart.from_string(
-        'NY21002000000000040000868888888888800000'
-        '0000000000000000000000000000000000000000'
+    record = AssignmentStart.from_string(
+        'NY210020000000000400008688888888888000000000000000000000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.ASSIGNMENT_START
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.ASSIGNMENT_START
 
-    assert record.assignment_type == netsgiro.AssignmentType.TRANSACTIONS
+    assert record.assignment_type == AssignmentType.TRANSACTIONS
 
     assert record.agreement_id == '000000000'
     assert record.assignment_number == '4000086'
@@ -62,17 +76,14 @@ def test_assignment_start_for_avtalegiro_payment_requests():
 
 
 def test_assignment_start_for_avtalegiro_agreements():
-    record = netsgiro.records.AssignmentStart.from_string(
-        'NY21242000000000040000868888888888800000'
-        '0000000000000000000000000000000000000000'
+    record = AssignmentStart.from_string(
+        'NY212420000000000400008688888888888000000000000000000000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.ASSIGNMENT_START
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.ASSIGNMENT_START
 
-    assert record.assignment_type == (
-        netsgiro.AssignmentType.AVTALEGIRO_AGREEMENTS
-    )
+    assert record.assignment_type == AssignmentType.AVTALEGIRO_AGREEMENTS
 
     assert record.agreement_id is None
     assert record.assignment_number == '4000086'
@@ -80,17 +91,14 @@ def test_assignment_start_for_avtalegiro_agreements():
 
 
 def test_assignment_start_for_avtalegiro_cancellation():
-    record = netsgiro.records.AssignmentStart.from_string(
-        'NY21362000000000040000868888888888800000'
-        '0000000000000000000000000000000000000000'
+    record = AssignmentStart.from_string(
+        'NY213620000000000400008688888888888000000000000000000000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.ASSIGNMENT_START
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.ASSIGNMENT_START
 
-    assert record.assignment_type == (
-        netsgiro.AssignmentType.AVTALEGIRO_CANCELLATIONS
-    )
+    assert record.assignment_type == AssignmentType.AVTALEGIRO_CANCELLATIONS
 
     assert record.agreement_id is None
     assert record.assignment_number == '4000086'
@@ -98,15 +106,14 @@ def test_assignment_start_for_avtalegiro_cancellation():
 
 
 def test_assignment_start_for_ocr_giro_transactions():
-    record = netsgiro.records.AssignmentStart.from_string(
-        'NY09002000100856600000029999104276400000'
-        '0000000000000000000000000000000000000000'
+    record = AssignmentStart.from_string(
+        'NY090020001008566000000299991042764000000000000000000000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.OCR_GIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.ASSIGNMENT_START
+    assert record.service_code == ServiceCode.OCR_GIRO
+    assert record.RECORD_TYPE == RecordType.ASSIGNMENT_START
 
-    assert record.assignment_type == netsgiro.AssignmentType.TRANSACTIONS
+    assert record.assignment_type == AssignmentType.TRANSACTIONS
 
     assert record.agreement_id == '001008566'
     assert record.assignment_number == '0000002'
@@ -114,15 +121,14 @@ def test_assignment_start_for_ocr_giro_transactions():
 
 
 def test_assignment_end_for_avtalegiro_payment_requests():
-    record = netsgiro.records.AssignmentEnd.from_string(
-        'NY21008800000006000000200000000000000060'
-        '0170604170604000000000000000000000000000'
+    record = AssignmentEnd.from_string(
+        'NY210088000000060000002000000000000000600170604170604000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.ASSIGNMENT_END
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.ASSIGNMENT_END
 
-    assert record.assignment_type == netsgiro.AssignmentType.TRANSACTIONS
+    assert record.assignment_type == AssignmentType.TRANSACTIONS
 
     assert record.num_transactions == 6
     assert record.num_records == 20
@@ -132,17 +138,14 @@ def test_assignment_end_for_avtalegiro_payment_requests():
 
 
 def test_assignment_end_for_avtalegiro_agreements():
-    record = netsgiro.records.AssignmentEnd.from_string(
-        'NY21248800000006000000200000000000000000'
-        '0000000000000000000000000000000000000000'
+    record = AssignmentEnd.from_string(
+        'NY212488000000060000002000000000000000000000000000000000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.ASSIGNMENT_END
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.ASSIGNMENT_END
 
-    assert record.assignment_type == (
-        netsgiro.AssignmentType.AVTALEGIRO_AGREEMENTS
-    )
+    assert record.assignment_type == AssignmentType.AVTALEGIRO_AGREEMENTS
 
     assert record.num_transactions == 6
     assert record.num_records == 20
@@ -152,17 +155,14 @@ def test_assignment_end_for_avtalegiro_agreements():
 
 
 def test_assignment_end_for_avtalegiro_cancellations():
-    record = netsgiro.records.AssignmentEnd.from_string(
-        'NY21368800000006000000200000000000000060'
-        '0170604170604000000000000000000000000000'
+    record = AssignmentEnd.from_string(
+        'NY213688000000060000002000000000000000600170604170604000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.ASSIGNMENT_END
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.ASSIGNMENT_END
 
-    assert record.assignment_type == (
-        netsgiro.AssignmentType.AVTALEGIRO_CANCELLATIONS
-    )
+    assert record.assignment_type == AssignmentType.AVTALEGIRO_CANCELLATIONS
 
     assert record.num_transactions == 6
     assert record.num_records == 20
@@ -172,15 +172,14 @@ def test_assignment_end_for_avtalegiro_cancellations():
 
 
 def test_assignment_end_for_ocr_giro_transactions():
-    record = netsgiro.records.AssignmentEnd.from_string(
-        'NY09008800000020000000420000000000514490'
-        '0200192200192200192000000000000000000000'
+    record = AssignmentEnd.from_string(
+        'NY090088000000200000004200000000005144900200192200192200192000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.OCR_GIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.ASSIGNMENT_END
+    assert record.service_code == ServiceCode.OCR_GIRO
+    assert record.RECORD_TYPE == RecordType.ASSIGNMENT_END
 
-    assert record.assignment_type == netsgiro.AssignmentType.TRANSACTIONS
+    assert record.assignment_type == AssignmentType.TRANSACTIONS
 
     assert record.num_transactions == 20
     assert record.num_records == 42
@@ -191,17 +190,14 @@ def test_assignment_end_for_ocr_giro_transactions():
 
 
 def test_transaction_amount_item_1_for_avtalegiro_payment_request():
-    record = netsgiro.records.TransactionAmountItem1.from_string(
-        'NY2121300000001170604           00000000'
-        '000000100          008000011688373000000'
+    record = TransactionAmountItem1.from_string(
+        'NY2121300000001170604           00000000000000100          008000011688373000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_AMOUNT_ITEM_1
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_AMOUNT_ITEM_1
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-    )
+    assert record.transaction_type == TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
     assert record.transaction_number == 1
 
     assert record.nets_date == date(2004, 6, 17)
@@ -210,17 +206,14 @@ def test_transaction_amount_item_1_for_avtalegiro_payment_request():
 
 
 def test_transaction_amount_item_1_for_avtalegiro_cancellation():
-    record = netsgiro.records.TransactionAmountItem1.from_string(
-        'NY2193300000001170604           00000000'
-        '000000100          008000011688373000000'
+    record = TransactionAmountItem1.from_string(
+        'NY2193300000001170604           00000000000000100          008000011688373000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_AMOUNT_ITEM_1
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_AMOUNT_ITEM_1
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.AVTALEGIRO_CANCELLATION
-    )
+    assert record.transaction_type == TransactionType.AVTALEGIRO_CANCELLATION
     assert record.transaction_number == 1
 
     assert record.nets_date == date(2004, 6, 17)
@@ -229,17 +222,14 @@ def test_transaction_amount_item_1_for_avtalegiro_cancellation():
 
 
 def test_transaction_amount_item_1_for_ocr_giro_transactions():
-    record = netsgiro.records.TransactionAmountItem1.from_string(
-        'NY09103000000012001921320101464000000000'
-        '000102000                  0000531000000'
+    record = TransactionAmountItem1.from_string(
+        'NY09103000000012001921320101464000000000000102000                  0000531000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.OCR_GIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_AMOUNT_ITEM_1
+    assert record.service_code == ServiceCode.OCR_GIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_AMOUNT_ITEM_1
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.FROM_GIRO_DEBITED_ACCOUNT
-    )
+    assert record.transaction_type == TransactionType.FROM_GIRO_DEBITED_ACCOUNT
     assert record.transaction_number == 1
 
     assert record.nets_date == date(1992, 1, 20)
@@ -255,17 +245,14 @@ def test_transaction_amount_item_1_for_ocr_giro_transactions():
 
 
 def test_transaction_amount_item_2_for_avtalegiro_payment_request():
-    record = netsgiro.records.TransactionAmountItem2.from_string(
-        'NY2121310000001NAVN                     '
-        '                                   00000'
+    record = TransactionAmountItem2.from_string(
+        'NY2121310000001NAVN                                                        00000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_AMOUNT_ITEM_2
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_AMOUNT_ITEM_2
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-    )
+    assert record.transaction_type == TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
     assert record.transaction_number == 1
 
     assert record.payer_name == 'NAVN'
@@ -273,17 +260,14 @@ def test_transaction_amount_item_2_for_avtalegiro_payment_request():
 
 
 def test_transaction_amount_item_2_for_ocr_giro_transactions():
-    record = netsgiro.records.TransactionAmountItem2.from_string(
-        'NY09103100000019636827194099038562000000'
-        '0160192999905123410000000000000000000000'
+    record = TransactionAmountItem2.from_string(
+        'NY091031000000196368271940990385620000000160192999905123410000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.OCR_GIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_AMOUNT_ITEM_2
+    assert record.service_code == ServiceCode.OCR_GIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_AMOUNT_ITEM_2
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.FROM_GIRO_DEBITED_ACCOUNT
-    )
+    assert record.transaction_type == TransactionType.FROM_GIRO_DEBITED_ACCOUNT
     assert record.transaction_number == 1
 
     assert record.form_number == '9636827194'
@@ -294,17 +278,14 @@ def test_transaction_amount_item_2_for_ocr_giro_transactions():
 
 
 def test_transaction_amount_item_2_for_ocr_giro_with_data_in_filler_field():
-    record = netsgiro.records.TransactionAmountItem2.from_string(
-        'NY09103100000029797596016097596016188320'
-        '6160192999910055240000000000000000000000'
+    record = TransactionAmountItem2.from_string(
+        'NY091031000000297975960160975960161883206160192999910055240000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.OCR_GIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_AMOUNT_ITEM_2
+    assert record.service_code == ServiceCode.OCR_GIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_AMOUNT_ITEM_2
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.FROM_GIRO_DEBITED_ACCOUNT
-    )
+    assert record.transaction_type == TransactionType.FROM_GIRO_DEBITED_ACCOUNT
     assert record.transaction_number == 2
 
     assert record.form_number == '9797596016'
@@ -316,34 +297,28 @@ def test_transaction_amount_item_2_for_ocr_giro_with_data_in_filler_field():
 
 
 def test_transaction_amount_item_3_for_ocr_giro_transactions():
-    record = netsgiro.records.TransactionAmountItem3.from_string(
-        'NY0921320000001Foo bar baz              '
-        '               0000000000000000000000000'
+    record = TransactionAmountItem3.from_string(
+        'NY0921320000001Foo bar baz                             0000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.OCR_GIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_AMOUNT_ITEM_3
+    assert record.service_code == ServiceCode.OCR_GIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_AMOUNT_ITEM_3
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.PURCHASE_WITH_TEXT
-    )
+    assert record.transaction_type == (TransactionType.PURCHASE_WITH_TEXT)
     assert record.transaction_number == 1
 
     assert record.text == 'Foo bar baz'
 
 
 def test_transaction_specification_for_avtalegiro_payment_request():
-    record = netsgiro.records.TransactionSpecification.from_string(
-        'NY212149000000140011 Gjelder Faktura: 16'
-        '8837  Dato: 19/03/0400000000000000000000'
+    record = TransactionSpecification.from_string(
+        'NY212149000000140011 Gjelder Faktura: 168837  Dato: 19/03/0400000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_SPECIFICATION
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_SPECIFICATION
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-    )
+    assert record.transaction_type == TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
     assert record.transaction_number == 1
 
     assert record.line_number == 1
@@ -351,13 +326,13 @@ def test_transaction_specification_for_avtalegiro_payment_request():
     assert record.text == ' Gjelder Faktura: 168837  Dato: 19/03/04'
 
 
-def make_specification_records(num_lines, num_columns=2):
+def make_specification_records(
+    num_lines: int, num_columns: int = 2
+) -> List[TransactionSpecification]:
     return [
-        netsgiro.records.TransactionSpecification(
-            service_code=netsgiro.ServiceCode.AVTALEGIRO,
-            transaction_type=(
-                netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-            ),
+        TransactionSpecification(
+            service_code=ServiceCode.AVTALEGIRO,
+            transaction_type=TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION,
             transaction_number=1,
             line_number=line,
             column_number=column,
@@ -371,7 +346,7 @@ def make_specification_records(num_lines, num_columns=2):
 def test_transaction_specification_to_text_with_max_number_of_records():
     records = make_specification_records(42)
 
-    result = netsgiro.records.TransactionSpecification.to_text(records)
+    result = TransactionSpecification.to_text(records)
 
     assert len(result.splitlines()) == 42
     assert 'Line 1, column 1' in result
@@ -381,49 +356,37 @@ def test_transaction_specification_to_text_with_max_number_of_records():
 def test_transaction_specification_to_text_with_too_many_records():
     records = make_specification_records(43)
 
-    with pytest.raises(
-        ValueError, match='Max 84 specification records allowed, got 86'
-    ):
-        netsgiro.records.TransactionSpecification.to_text(records)
+    with pytest.raises(ValueError, match='Max 84 specification records allowed, got 86'):
+        TransactionSpecification.to_text(records)
 
 
 def test_avtalegiro_active_agreement():
-    record = netsgiro.records.AvtaleGiroAgreement.from_string(
-        'NY21947000000010          00800001168837'
-        '3J00000000000000000000000000000000000000'
+    record = AvtaleGiroAgreement.from_string(
+        'NY21947000000010          008000011688373J00000000000000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_AGREEMENTS
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_AGREEMENTS
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.AVTALEGIRO_AGREEMENT
-    )
+    assert record.transaction_type == TransactionType.AVTALEGIRO_AGREEMENT
     assert record.transaction_number == 1
 
-    assert record.registration_type == (
-        netsgiro.AvtaleGiroRegistrationType.ACTIVE_AGREEMENT
-    )
+    assert record.registration_type == AvtaleGiroRegistrationType.ACTIVE_AGREEMENT
     assert record.kid == '008000011688373'
     assert record.notify is True
 
 
 def test_avtalegiro_new_or_updated_agreement():
-    record = netsgiro.records.AvtaleGiroAgreement.from_string(
-        'NY21947000000011          00800001168837'
-        '3N00000000000000000000000000000000000000'
+    record = AvtaleGiroAgreement.from_string(
+        'NY21947000000011          008000011688373N00000000000000000000000000000000000000'
     )
 
-    assert record.service_code == netsgiro.ServiceCode.AVTALEGIRO
-    assert record.RECORD_TYPE == netsgiro.RecordType.TRANSACTION_AGREEMENTS
+    assert record.service_code == ServiceCode.AVTALEGIRO
+    assert record.RECORD_TYPE == RecordType.TRANSACTION_AGREEMENTS
 
-    assert record.transaction_type == (
-        netsgiro.TransactionType.AVTALEGIRO_AGREEMENT
-    )
+    assert record.transaction_type == TransactionType.AVTALEGIRO_AGREEMENT
     assert record.transaction_number == 1
 
-    assert record.registration_type == (
-        netsgiro.AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT
-    )
+    assert record.registration_type == AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT
     assert record.kid == '008000011688373'
     assert record.notify is False

--- a/tests/test_record_properties.py
+++ b/tests/test_record_properties.py
@@ -196,14 +196,10 @@ def test_transaction_amount_item_1_for_ocr_giro_transactions(
     a=st.integers(min_value=0, max_value=99999999999999999),
     kid=digits(min_size=4, max_size=25),
 )
-def test_transaction_amount_item_1_for_avtalegiro_payment_requests(
-    tn, nd, a, kid
-):
+def test_transaction_amount_item_1_for_avtalegiro_payment_requests(tn, nd, a, kid):
     original = netsgiro.records.TransactionAmountItem1(
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
-        transaction_type=(
-            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-        ),
+        transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
         transaction_number=tn,
         nets_date=nd,
         amount=a,
@@ -223,9 +219,7 @@ def test_transaction_amount_item_1_for_avtalegiro_payment_requests(
 def test_transaction_amount_item_2_for_avtalegiro_payment_request(tn, pn):
     original = netsgiro.records.TransactionAmountItem2(
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
-        transaction_type=(
-            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-        ),
+        transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
         transaction_number=tn,
         reference=None,
         payer_name=pn,
@@ -245,9 +239,7 @@ def test_transaction_amount_item_2_for_avtalegiro_payment_request(tn, pn):
     bd=dates(),
     da=digits(11),
 )
-def test_transaction_amount_item_2_for_ocr_giro_transactions(
-    tn, ref, fn, bd, da
-):
+def test_transaction_amount_item_2_for_ocr_giro_transactions(tn, ref, fn, bd, da):
     original = netsgiro.records.TransactionAmountItem2(
         service_code=netsgiro.ServiceCode.OCR_GIRO,
         transaction_type=(netsgiro.TransactionType.FROM_GIRO_DEBITED_ACCOUNT),
@@ -269,9 +261,7 @@ def test_transaction_amount_item_2_for_ocr_giro_transactions(
     assert record.debit_account == da
 
 
-@given(
-    tn=st.integers(min_value=0, max_value=9999999), text=st.text(max_size=40)
-)
+@given(tn=st.integers(min_value=0, max_value=9999999), text=st.text(max_size=40))
 def test_transaction_amount_item_3_for_ocr_giro_transactions(tn, text):
     original = netsgiro.records.TransactionAmountItem3(
         service_code=netsgiro.ServiceCode.OCR_GIRO,
@@ -293,14 +283,10 @@ def test_transaction_amount_item_3_for_ocr_giro_transactions(tn, text):
     cn=st.integers(min_value=1, max_value=2),
     text=st.text(min_size=40, max_size=40),
 )
-def test_transaction_specification_for_avtalegiro_payment_request(
-    tn, ln, cn, text
-):
+def test_transaction_specification_for_avtalegiro_payment_request(tn, ln, cn, text):
     original = netsgiro.records.TransactionSpecification(
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
-        transaction_type=(
-            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-        ),
+        transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
         transaction_number=tn,
         line_number=ln,
         column_number=cn,
@@ -327,9 +313,7 @@ def test_avtalegiro_agreement(tn, kid, n):
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
         transaction_type=(netsgiro.TransactionType.AVTALEGIRO_AGREEMENT),
         transaction_number=tn,
-        registration_type=(
-            netsgiro.AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT
-        ),
+        registration_type=(netsgiro.AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT),
         kid=kid,
         notify=n,
     )

--- a/tests/test_record_writing.py
+++ b/tests/test_record_writing.py
@@ -16,8 +16,7 @@ def test_transmission_start():
 
     assert (
         record.to_ocr()
-        == 'NY00001055555555100008100008080000000000'
-        '0000000000000000000000000000000000000000'
+        == 'NY000010555555551000081000080800000000000000000000000000000000000000000000000000'
     )
 
 
@@ -55,8 +54,7 @@ def test_transmission_end():
 
     assert (
         record.to_ocr()
-        == 'NY00008900000006000000220000000000000060'
-        '0170604000000000000000000000000000000000'
+        == 'NY000089000000060000002200000000000000600170604000000000000000000000000000000000'
     )
 
 
@@ -69,9 +67,7 @@ def test_transmission_end():
         (6, 22, 600, '2004-06-17', ValueError),
     ],
 )
-def test_transmission_end_with_invalid_data(
-    num_tx, num_records, total_amount, nets_date, exc
-):
+def test_transmission_end_with_invalid_data(num_tx, num_records, total_amount, nets_date, exc):
     with pytest.raises(exc):
         netsgiro.records.TransmissionEnd(
             service_code=netsgiro.ServiceCode.NONE,
@@ -93,8 +89,7 @@ def test_assignment_start_for_avtalegiro_payment_requests():
 
     assert (
         record.to_ocr()
-        == 'NY21002000000011140000868888888888800000'
-        '0000000000000000000000000000000000000000'
+        == 'NY210020000000111400008688888888888000000000000000000000000000000000000000000000'
     )
 
 
@@ -109,8 +104,7 @@ def test_assignment_start_for_avtalegiro_agreements():
 
     assert (
         record.to_ocr()
-        == 'NY21242000000000040000868888888888800000'
-        '0000000000000000000000000000000000000000'
+        == 'NY212420000000000400008688888888888000000000000000000000000000000000000000000000'
     )
 
 
@@ -149,8 +143,7 @@ def test_assignment_end_for_avtalegiro_payment_requests():
 
     assert (
         record.to_ocr()
-        == 'NY21008800000006000000200000000000000060'
-        '0170604170604000000000000000000000000000'
+        == 'NY210088000000060000002000000000000000600170604170604000000000000000000000000000'
     )
 
 
@@ -164,8 +157,7 @@ def test_assignment_end_for_avtalegiro_agreements():
 
     assert (
         record.to_ocr()
-        == 'NY21248800000006000000200000000000000000'
-        '0000000000000000000000000000000000000000'
+        == 'NY212488000000060000002000000000000000000000000000000000000000000000000000000000'
     )
 
 
@@ -186,17 +178,14 @@ def test_transaction_amount_item_1_for_ocr_giro_transactions():
 
     assert (
         record.to_ocr()
-        == 'NY09103000000012001921320101464000000000'
-        '000102000                  0000531000000'
+        == 'NY09103000000012001921320101464000000000000102000                  0000531000000'
     )
 
 
 def test_transaction_amount_item_1_for_avtalegiro_payment_requests():
     record = netsgiro.records.TransactionAmountItem1(
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
-        transaction_type=(
-            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-        ),
+        transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
         transaction_number=1,
         nets_date=date(2004, 6, 17),
         amount=100,
@@ -205,8 +194,7 @@ def test_transaction_amount_item_1_for_avtalegiro_payment_requests():
 
     assert (
         record.to_ocr()
-        == 'NY2121300000001170604           00000000'
-        '000000100          008000011688373000000'
+        == 'NY2121300000001170604           00000000000000100          008000011688373000000'
     )
 
 
@@ -214,9 +202,7 @@ def test_transaction_amount_item_1_raises_if_kid_is_too_long():
     with pytest.raises(ValueError, match='kid must be at most 25 chars'):
         netsgiro.records.TransactionAmountItem1(
             service_code=netsgiro.ServiceCode.AVTALEGIRO,
-            transaction_type=(
-                netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-            ),
+            transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
             transaction_number=1,
             nets_date=date(2004, 6, 17),
             amount=100,
@@ -227,9 +213,7 @@ def test_transaction_amount_item_1_raises_if_kid_is_too_long():
 def test_transaction_amount_item_2_for_avtalegiro_payment_request():
     record = netsgiro.records.TransactionAmountItem2(
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
-        transaction_type=(
-            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-        ),
+        transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
         transaction_number=1,
         reference=None,
         payer_name='NAVN',
@@ -237,8 +221,7 @@ def test_transaction_amount_item_2_for_avtalegiro_payment_request():
 
     assert (
         record.to_ocr()
-        == 'NY2121310000001NAVN                     '
-        '                                   00000'
+        == 'NY2121310000001NAVN                                                        00000'
     )
 
 
@@ -253,9 +236,7 @@ def test_transaction_amount_item_2_for_avtalegiro_payment_request():
 def test_transaction_amount_item_2_payer_name_behavior(payer_name, expected):
     original = netsgiro.records.TransactionAmountItem2(
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
-        transaction_type=(
-            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-        ),
+        transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
         transaction_number=1,
         reference=None,
         payer_name=payer_name,
@@ -280,8 +261,7 @@ def test_transaction_amount_item_2_for_ocr_giro_transactions():
 
     assert (
         record.to_ocr()
-        == 'NY09103100000019636827194099038562000000'
-        '0160192999905123410000000000000000000000'
+        == 'NY091031000000196368271940990385620000000160192999905123410000000000000000000000'
     )
 
 
@@ -298,8 +278,7 @@ def test_transaction_amount_item_2_for_ocr_giro_without_bank_date():
 
     assert (
         record.to_ocr()
-        == 'NY09103100000019636827194099038562000000'
-        '0000000999905123410000000000000000000000'
+        == 'NY091031000000196368271940990385620000000000000999905123410000000000000000000000'
     )
 
 
@@ -313,8 +292,7 @@ def test_transaction_amount_item_3_for_ocr_giro_transactions():
 
     assert (
         record.to_ocr()
-        == 'NY0921320000001Foo bar baz              '
-        '               0000000000000000000000000'
+        == 'NY0921320000001Foo bar baz                             0000000000000000000000000'
     )
 
 
@@ -352,9 +330,7 @@ def test_transaction_amount_item_3_raises_if_text_is_too_long():
 def test_transaction_specification_for_avtalegiro_payment_request():
     record = netsgiro.records.TransactionSpecification(
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
-        transaction_type=(
-            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-        ),
+        transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
         transaction_number=1,
         line_number=1,
         column_number=1,
@@ -363,8 +339,7 @@ def test_transaction_specification_for_avtalegiro_payment_request():
 
     assert (
         record.to_ocr()
-        == 'NY212149000000140011 Gjelder Faktura: 16'
-        '8837  Dato: 19/03/0400000000000000000000'
+        == 'NY212149000000140011 Gjelder Faktura: 168837  Dato: 19/03/0400000000000000000000'
     )
 
 
@@ -372,9 +347,7 @@ def test_transaction_specification_from_longer_text():
     records = list(
         netsgiro.records.TransactionSpecification.from_text(
             service_code=netsgiro.ServiceCode.AVTALEGIRO,
-            transaction_type=(
-                netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-            ),
+            transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
             transaction_number=1,
             text=' Gjelder Faktura: 168837  Dato: 19/03/04\nFoo bar baz quux',
         )
@@ -383,23 +356,19 @@ def test_transaction_specification_from_longer_text():
     assert len(records) == 4
     assert (
         records[0].to_ocr()
-        == 'NY212149000000140011 Gjelder Faktura: 16'
-        '8837  Dato: 19/03/0400000000000000000000'
+        == 'NY212149000000140011 Gjelder Faktura: 168837  Dato: 19/03/0400000000000000000000'
     )
     assert (
         records[1].to_ocr()
-        == 'NY212149000000140012                    '
-        '                    00000000000000000000'
+        == 'NY212149000000140012                                        00000000000000000000'
     )
     assert (
         records[2].to_ocr()
-        == 'NY212149000000140021Foo bar baz quux    '
-        '                    00000000000000000000'
+        == 'NY212149000000140021Foo bar baz quux                        00000000000000000000'
     )
     assert (
         records[3].to_ocr()
-        == 'NY212149000000140022                    '
-        '                    00000000000000000000'
+        == 'NY212149000000140022                                        00000000000000000000'
     )
 
 
@@ -417,9 +386,7 @@ def test_transaction_specification_from_longer_text():
 def test_transaction_specification_text_behavior(text, expected):
     original = netsgiro.records.TransactionSpecification(
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
-        transaction_type=(
-            netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-        ),
+        transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
         transaction_number=1,
         line_number=1,
         column_number=1,
@@ -439,9 +406,7 @@ def test_transaction_specification_raises_if_text_is_too_long():
     with pytest.raises(ValueError, match='text must be at most 40 chars'):
         netsgiro.records.TransactionSpecification(
             service_code=netsgiro.ServiceCode.AVTALEGIRO,
-            transaction_type=(
-                netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION
-            ),
+            transaction_type=(netsgiro.TransactionType.AVTALEGIRO_WITH_BANK_NOTIFICATION),
             transaction_number=1,
             line_number=1,
             column_number=1,
@@ -454,17 +419,14 @@ def test_avtalegiro_agreement():
         service_code=netsgiro.ServiceCode.AVTALEGIRO,
         transaction_type=(netsgiro.TransactionType.AVTALEGIRO_AGREEMENT),
         transaction_number=1,
-        registration_type=(
-            netsgiro.AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT
-        ),
+        registration_type=(netsgiro.AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT),
         kid='008000011688373',
         notify=False,
     )
 
     assert (
         record.to_ocr()
-        == 'NY21947000000011          00800001168837'
-        '3N00000000000000000000000000000000000000'
+        == 'NY21947000000011          008000011688373N00000000000000000000000000000000000000'
     )
 
 
@@ -474,9 +436,7 @@ def test_avtalegiro_agreement_raises_if_kid_is_too_long():
             service_code=netsgiro.ServiceCode.AVTALEGIRO,
             transaction_type=(netsgiro.TransactionType.AVTALEGIRO_AGREEMENT),
             transaction_number=1,
-            registration_type=(
-                netsgiro.AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT
-            ),
+            registration_type=(netsgiro.AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT),
             kid='008000011688373' * 4,  # Max 25 chars
             notify=False,
         )

--- a/tests/test_records_api.py
+++ b/tests/test_records_api.py
@@ -12,9 +12,7 @@ def test_parse_with_too_short_lines_fails():
 
 
 def test_parse_with_nonnumeric_record_type():
-    with pytest.raises(
-        ValueError, match="Record type must be numeric, got 'AA'"
-    ):
+    with pytest.raises(ValueError, match="Record type must be numeric, got 'AA'"):
         netsgiro.records.parse('NY0000AA' + '0' * 72)
 
 
@@ -91,27 +89,19 @@ def test_parse_avtalegiro_payment_requests(payment_request_data):
     assert isinstance(assignment_start, netsgiro.records.AssignmentStart)
     assert assignment_start.assignment_account == '88888888888'
 
-    assert isinstance(
-        transaction_amount_1, netsgiro.records.TransactionAmountItem1
-    )
+    assert isinstance(transaction_amount_1, netsgiro.records.TransactionAmountItem1)
     assert transaction_amount_1.nets_date == date(2004, 6, 17)
     assert transaction_amount_1.amount == 100
     assert transaction_amount_1.kid == '008000011688373'
 
-    assert isinstance(
-        transaction_amount_2, netsgiro.records.TransactionAmountItem2
-    )
+    assert isinstance(transaction_amount_2, netsgiro.records.TransactionAmountItem2)
     assert transaction_amount_2.payer_name == 'NAVN'
     assert transaction_amount_2.reference is None
 
-    assert isinstance(
-        transaction_spec_1, netsgiro.records.TransactionSpecification
-    )
+    assert isinstance(transaction_spec_1, netsgiro.records.TransactionSpecification)
     assert transaction_spec_1.text == ' Gjelder Faktura: 168837  Dato: 19/03/04'
 
-    assert isinstance(
-        transaction_spec_2, netsgiro.records.TransactionSpecification
-    )
+    assert isinstance(transaction_spec_2, netsgiro.records.TransactionSpecification)
     assert transaction_spec_2.text == '                  ForfallsDato: 17/06/04'
 
     assert isinstance(assignment_end, netsgiro.records.AssignmentEnd)
@@ -148,25 +138,19 @@ def test_parse_ocr_giro_transactions(ocr_giro_transactions_data):
     assert isinstance(assignment_start, netsgiro.records.AssignmentStart)
     assert assignment_start.assignment_account == '99991042764'
 
-    assert isinstance(
-        transaction_amount_1, netsgiro.records.TransactionAmountItem1
-    )
+    assert isinstance(transaction_amount_1, netsgiro.records.TransactionAmountItem1)
     assert transaction_amount_1.nets_date == date(1992, 1, 20)
     assert transaction_amount_1.amount == 102000
     assert transaction_amount_1.kid == '0000531'
 
-    assert isinstance(
-        transaction_amount_2, netsgiro.records.TransactionAmountItem2
-    )
+    assert isinstance(transaction_amount_2, netsgiro.records.TransactionAmountItem2)
     assert transaction_amount_2.payer_name is None
     assert transaction_amount_2.form_number == '9636827194'
     assert transaction_amount_2.reference == '099038562'
     assert transaction_amount_2.bank_date == date(1992, 1, 16)
     assert transaction_amount_2.debit_account == '99990512341'
 
-    assert isinstance(
-        transaction_amount_3, netsgiro.records.TransactionAmountItem3
-    )
+    assert isinstance(transaction_amount_3, netsgiro.records.TransactionAmountItem3)
     assert transaction_amount_3.text == 'Foo bar baz'
 
     assert isinstance(assignment_end, netsgiro.records.AssignmentEnd)


### PR DESCRIPTION
With lines changing like this:

```diff
-     field = attr.ib(default=None, converter=some_converter)
+     field: Optional[str] = attr.ib(default=None, converter=some_converter)
```

forcing 80 line length is creating a lot of hard-to-read formatting. This ups the limit to 100.