### PR TITLE
Annotating netsgiro 1/9: Add date converter

### DIFF
--- a/netsgiro/converters.py
+++ b/netsgiro/converters.py
@@ -78,6 +78,13 @@ def to_avtalegiro_registration_type(
 
 
 def to_date(value: Union[datetime.date, str]) -> Optional[datetime.date]:
+    """Convert input to date."""
+    if isinstance(value, datetime.date):
+        return value
+    return datetime.datetime.strptime(value, '%d%m%y').date()
+
+
+def to_date_or_none(value: Union[datetime.date, str]) -> Optional[datetime.date]:
     """Convert input to date or None."""
     if isinstance(value, datetime.date):
         return value

--- a/netsgiro/converters.py
+++ b/netsgiro/converters.py
@@ -50,25 +50,35 @@ def fixed_len_str(length: int, converter: Callable[[Any], T]) -> Callable[[Any],
     return lambda value: converter('{value:{length}}'.format(value=value, length=length))
 
 
+to_safe_str_or_none: Callable = value_or_none(
+    stripped_newlines(stripped_spaces_around(truthy_or_none(str)))
+)
+
+
 def to_service_code(value: Union[ServiceCode, int, str]) -> ServiceCode:
+    """Convert input to ServiceCode."""
     return ServiceCode(int(value))
 
 
 def to_assignment_type(value: Union[AssignmentType, int, str]) -> AssignmentType:
+    """Convert input to AssignmentType."""
     return AssignmentType(int(value))
 
 
 def to_transaction_type(value: Union[TransactionType, int, str]) -> TransactionType:
+    """Convert input to TransactionType."""
     return TransactionType(int(value))
 
 
 def to_avtalegiro_registration_type(
     value: Union[AvtaleGiroRegistrationType, int, str]
 ) -> AvtaleGiroRegistrationType:
+    """Convert input to AvtaleGiroRegistrationType."""
     return AvtaleGiroRegistrationType(int(value))
 
 
-def to_date(value: Union[datetime.date, str, None]) -> Optional[datetime.date]:
+def to_date(value: Union[datetime.date, str]) -> Optional[datetime.date]:
+    """Convert input to date or None."""
     if isinstance(value, datetime.date):
         return value
     if value is None or value == '000000':
@@ -77,6 +87,7 @@ def to_date(value: Union[datetime.date, str, None]) -> Optional[datetime.date]:
 
 
 def to_bool(value: Union[bool, str]) -> bool:
+    """Convert input to bool."""
     if isinstance(value, bool):
         return value
     if value == 'J':
@@ -85,6 +96,3 @@ def to_bool(value: Union[bool, str]) -> bool:
         return False
     else:
         raise ValueError(f"Expected 'J' or 'N', got {value!r}")
-
-
-to_safe_str_or_none = value_or_none(stripped_newlines(stripped_spaces_around(truthy_or_none(str))))

--- a/netsgiro/objects.py
+++ b/netsgiro/objects.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from netsgiro.enums import AvtaleGiroRegistrationType
     from netsgiro.records import Record, TransactionRecord
 
-__all__ = [
+__all__: List[str] = [
     'Transmission',
     'Assignment',
     'Agreement',
@@ -51,8 +51,7 @@ class Transmission:
     multiple :class:`~netsgiro.Assignment` objects of various types.
     """
 
-    #: Data transmitters unique enumeration of the transmission. String of 7
-    #: digits.
+    #: Data transmitters unique enumeration of the transmission. String of 7 digits.
     number: str = attr.ib(validator=str_of_length(7))
 
     #: Data transmitter's Nets ID. String of 8 digits.

--- a/netsgiro/objects.py
+++ b/netsgiro/objects.py
@@ -70,7 +70,7 @@ class Transmission:
     )
 
     #: List of assignments.
-    assignments: list['Assignment'] = attr.ib(default=attr.Factory(list), repr=False)
+    assignments: List['Assignment'] = attr.ib(default=attr.Factory(list), repr=False)
 
     @classmethod
     def from_records(cls, records: List['Record']) -> 'Transmission':
@@ -93,7 +93,7 @@ class Transmission:
 
     @staticmethod
     def _get_assignments(records: List['Record']) -> List['Assignment']:
-        assignments: OrderedDict[int, list['Record']] = OrderedDict()
+        assignments: OrderedDict[int, List['Record']] = OrderedDict()
 
         current_assignment_number = None
         for record in records:
@@ -224,7 +224,7 @@ class Assignment:
 
     #: List of transaction objects, like :class:`~netsgiro.Agreement`,
     #: :class:`~netsgiro.PaymentRequest`, :class:`~netsgiro.Transaction`.
-    transactions: list['Transaction'] = attr.ib(default=attr.Factory(list), repr=False)
+    transactions: List['Transaction'] = attr.ib(default=attr.Factory(list), repr=False)
 
     _next_transaction_number: int = attr.ib(default=1, init=False)
 
@@ -277,7 +277,7 @@ class Assignment:
     def _group_by_transaction_number(
         records: List['Record'],
     ) -> Mapping[int, List['Record']]:
-        transactions: OrderedDict[int, list['TransactionRecord']] = OrderedDict()
+        transactions: OrderedDict[int, List['TransactionRecord']] = OrderedDict()
 
         transaction_record: 'TransactionRecord'
         for transaction_record in records:

--- a/netsgiro/records.py
+++ b/netsgiro/records.py
@@ -15,6 +15,7 @@ from netsgiro.converters import (
     to_avtalegiro_registration_type,
     to_bool,
     to_date,
+    to_date_or_none,
     to_safe_str_or_none,
     to_service_code,
     to_transaction_type,
@@ -112,7 +113,7 @@ class TransmissionEnd(Record):
     num_transactions = attr.ib(converter=int)
     num_records = attr.ib(converter=int)
     total_amount = attr.ib(converter=int)
-    nets_date = attr.ib(converter=to_date)
+    nets_date: 'datetime.date' = attr.ib(converter=to_date)
 
     RECORD_TYPE = netsgiro.RecordType.TRANSMISSION_END
     _PATTERNS = [
@@ -239,9 +240,9 @@ class AssignmentEnd(Record):
 
     # Only for transactions and cancellations
     total_amount = attr.ib(default=None, converter=value_or_none(int))
-    nets_date_1 = attr.ib(default=None, converter=to_date)
-    nets_date_2 = attr.ib(default=None, converter=to_date)
-    nets_date_3 = attr.ib(default=None, converter=to_date)
+    nets_date_1: Optional['datetime.date'] = attr.ib(default=None, converter=to_date_or_none)
+    nets_date_2: Optional['datetime.date'] = attr.ib(default=None, converter=to_date_or_none)
+    nets_date_3: Optional['datetime.date'] = attr.ib(default=None, converter=to_date_or_none)
 
     RECORD_TYPE = netsgiro.RecordType.ASSIGNMENT_END
     _PATTERNS = [
@@ -464,7 +465,7 @@ class TransactionAmountItem2(TransactionRecord):
 
     # Only OCR Giro
     form_number = attr.ib(default=None, validator=optional(str_of_length(10)))
-    bank_date = attr.ib(default=None, converter=to_date)
+    bank_date: Optional['datetime.date'] = attr.ib(default=None, converter=to_date_or_none)
     debit_account = attr.ib(default=None, validator=optional(str_of_length(11)))
     # XXX In use in OCR Giro "from giro debited account" transactions in test
     # data, but documented as a filler field.

--- a/netsgiro/records.py
+++ b/netsgiro/records.py
@@ -26,9 +26,9 @@ from netsgiro.validators import str_of_length, str_of_max_length
 if TYPE_CHECKING:
     import datetime
 
-    from netsgiro import AvtaleGiroRegistrationType, TransactionType
+    from netsgiro import AssignmentType, AvtaleGiroRegistrationType, ServiceCode, TransactionType
 
-__all__ = [
+__all__: List[str] = [
     'TransmissionStart',
     'TransmissionEnd',
     'AssignmentStart',
@@ -44,7 +44,7 @@ __all__ = [
 
 @attr.s
 class Record:
-    service_code = attr.ib(converter=to_service_code)
+    service_code: 'ServiceCode' = attr.ib(converter=to_service_code)
 
     _PATTERNS = []
 
@@ -156,7 +156,7 @@ class AssignmentStart(Record):
     Each assignment can contain any number of transactions.
     """
 
-    assignment_type = attr.ib(converter=to_assignment_type)
+    assignment_type: 'AssignmentType' = attr.ib(converter=to_assignment_type)
     assignment_number = attr.ib(validator=str_of_length(7))
     assignment_account = attr.ib(validator=str_of_length(11))
 
@@ -234,7 +234,7 @@ class AssignmentStart(Record):
 class AssignmentEnd(Record):
     """AssignmentEnd is the last record of an assignment."""
 
-    assignment_type = attr.ib(converter=to_assignment_type)
+    assignment_type: 'AssignmentType' = attr.ib(converter=to_assignment_type)
     num_transactions = attr.ib(converter=int)
     num_records = attr.ib(converter=int)
 
@@ -461,7 +461,7 @@ class TransactionAmountItem2(TransactionRecord):
     """
 
     # TODO Validate `reference` length, which depends on service code
-    reference = attr.ib(converter=to_safe_str_or_none)
+    reference: Optional[str] = attr.ib(converter=to_safe_str_or_none)
 
     # Only OCR Giro
     form_number = attr.ib(default=None, validator=optional(str_of_length(10)))
@@ -472,7 +472,7 @@ class TransactionAmountItem2(TransactionRecord):
     _filler = attr.ib(default=None)
 
     # Only AvtaleGiro
-    payer_name = attr.ib(default=None, converter=to_safe_str_or_none)
+    payer_name: Optional[str] = attr.ib(default=None, converter=to_safe_str_or_none)
 
     RECORD_TYPE = netsgiro.RecordType.TRANSACTION_AMOUNT_ITEM_2
     _PATTERNS = [
@@ -554,7 +554,9 @@ class TransactionAmountItem3(TransactionRecord):
     The record is only used for some OCR Giro transaction types.
     """
 
-    text = attr.ib(converter=to_safe_str_or_none, validator=optional(str_of_max_length(40)))
+    text: Optional[str] = attr.ib(
+        converter=to_safe_str_or_none, validator=optional(str_of_max_length(40))
+    )
 
     RECORD_TYPE = netsgiro.RecordType.TRANSACTION_AMOUNT_ITEM_3
     _PATTERNS = [


### PR DESCRIPTION
Adds new `to_date` converter and annotates all `attr.ib` definitions containing converters.

Related to the typing entry in #14