### PR TITLE
Annotating netsgiro 9/9: Make package PEP 561-compatible by adding py.typed

### DIFF
--- a/netsgiro/converters.py
+++ b/netsgiro/converters.py
@@ -88,7 +88,7 @@ def to_avtalegiro_registration_type(
     return AvtaleGiroRegistrationType(int(value))
 
 
-def to_date(value: Union[datetime.date, str]) -> Optional[datetime.date]:
+def to_date(value: Union[datetime.date, str]) -> datetime.date:
     """Convert input to date."""
     if isinstance(value, datetime.date):
         return value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers=[
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
+    'Typing :: Typed'
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
Relates to #14 

https://peps.python.org/pep-0561/

https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

Adding a `py.typed` file tells type checkers (e.g., mypy) to use the new type hints.