### PR TITLE
chore: Add sourcery config with python-version

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,4 @@
+# https://docs.sourcery.ai/Configuration/Project-Settings/
+
+refactor:
+  python_version: '3.7'


### PR DESCRIPTION
We keep getting suggestions of walrus operator improvements that would break package compatibility for < 3.8. Think this should fix that.