### PR TITLE
Add package publication workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: publish package to pypi
+
+on:
+  release:
+    types: [published, edited]
+
+jobs:
+  build-and-publish:
+    needs: build-and-publish-test
+    name: Build and publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - uses: snok/install-poetry@v1
+      - name: Publish to pypi
+        run: |
+          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+          poetry publish --build --no-interaction


### PR DESCRIPTION
Relates to #14 

This requires you to add a `PYPI_TOKEN` to the repo secrets @klette, before we can run it.