### PR TITLE
Test uncovered code

### DIFF
--- a/netsgiro/objects.py
+++ b/netsgiro/objects.py
@@ -274,7 +274,7 @@ class Assignment:
             else:
                 # -> List[PaymentRequest]
                 cb = cls._get_payment_requests
-        else:
+        else:  # pragma: no cover
             raise ValueError(f'Unknown service code: {start.service_code}')
 
         transactions: TS = cb(body)
@@ -342,7 +342,7 @@ class Assignment:
                 'nets_date_1': self.get_earliest_transaction_date(),
                 'nets_date_2': self.get_latest_transaction_date(),
             }
-        else:
+        else:  # pragma: no cover
             raise ValueError(f'Unhandled service code: {self.service_code}')
 
         return AssignmentEnd(

--- a/netsgiro/records.py
+++ b/netsgiro/records.py
@@ -325,10 +325,7 @@ class AssignmentEnd(Record):
 
         Only used for OCR Giro.
         """
-        if self.service_code == ServiceCode.OCR_GIRO:
-            return self.nets_date_1
-        else:
-            return None
+        return self.nets_date_1 if self.service_code == ServiceCode.OCR_GIRO else None
 
     @property
     def nets_date_earliest(self) -> Optional['datetime.date']:

--- a/netsgiro/records.py
+++ b/netsgiro/records.py
@@ -78,7 +78,6 @@ class Record(ABC):
     @abstractmethod
     def to_ocr(self) -> str:
         """Get record as OCR string."""
-        ...
 
 
 @attr.s
@@ -338,7 +337,7 @@ class AssignmentEnd(Record):
             return self.nets_date_2
         elif self.service_code == ServiceCode.AVTALEGIRO:
             return self.nets_date_1
-        else:
+        else:  # pragma: no cover
             raise ValueError(f'Unhandled service code: {self.service_code}')
 
     @property
@@ -348,7 +347,7 @@ class AssignmentEnd(Record):
             return self.nets_date_3
         elif self.service_code == ServiceCode.AVTALEGIRO:
             return self.nets_date_2
-        else:
+        else:  # pragma: no cover
             raise ValueError(f'Unhandled service code: {self.service_code}')
 
     def to_ocr(self) -> str:
@@ -562,7 +561,7 @@ class TransactionAmountItem2(TransactionRecord):
                 + (self.reference and f'{self.reference:25}' or (' ' * 25))
                 + ('0' * 5)
             )
-        else:
+        else:  # pragma: no cover
             service_fields = ' ' * 35
 
         return common_fields + service_fields

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,4 +67,5 @@ show_missing = true
 skip_covered = true
 exclude_lines = [
     'if TYPE_CHECKING:',
+    'pragma: no cover',
 ]

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,0 +1,33 @@
+import pytest
+
+from netsgiro.converters import value_or_none, truthy_or_none, to_bool
+
+values = [
+    (int, None, None, None),
+    (int, 1, 1, 1),
+    (int, 1.5, 1, 1),
+    (float, 1.5, 1.5, 1.5),
+    (bool, 1.5, True, True),
+    (bool, 0, False, None),  # different
+]
+
+
+@pytest.mark.parametrize('c, v, v1, v2', values)
+def test_value_or_none(c, v, v1, v2):
+    """
+    Test the value or none and truthy or none converters.
+
+    They're almost identical.
+    """
+    assert value_or_none(c)(v) == v1
+    assert truthy_or_none(c)(v) == v2
+
+
+def test_to_bool():
+    assert to_bool(True) is True
+    assert to_bool(False) is False
+    assert to_bool('J') is True
+    assert to_bool('N') is False
+    for v in [None, 'S', '', [], {}]:
+        with pytest.raises(ValueError, match="Expected 'J' or 'N', got "):
+            to_bool(v)

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,6 +1,6 @@
 import pytest
 
-from netsgiro.converters import value_or_none, truthy_or_none, to_bool
+from netsgiro.converters import to_bool, truthy_or_none, value_or_none
 
 values = [
     (int, None, None, None),

--- a/tests/test_object_building.py
+++ b/tests/test_object_building.py
@@ -1,6 +1,8 @@
 from datetime import date
 from decimal import Decimal
 
+import pytest
+
 import netsgiro
 
 
@@ -75,3 +77,91 @@ def test_transmission_with_single_payment_request_transaction():
     assert tx2_spec2.line_number == 1
     assert tx2_spec2.column_number == 2
     assert tx2_spec2.text == '                                        '
+
+
+assignment_data = {
+    'kid': '000133700501645',
+    'due_date': date(2017, 4, 6),
+    'amount': Decimal('5244.63'),
+    'reference': 'ACME invoice #50164',
+    'payer_name': 'Wonderland',
+    'bank_notification': False,
+}
+
+
+def test_transmission_add_payment_cancellation():
+    """
+    Test adding a payment cancellation.
+    """
+    transmission = netsgiro.Transmission(
+        number='1703231',
+        data_transmitter='01234567',
+        data_recipient=netsgiro.NETS_ID,
+    )
+    assignment = transmission.add_assignment(
+        service_code=netsgiro.ServiceCode.AVTALEGIRO,
+        assignment_type=netsgiro.AssignmentType.AVTALEGIRO_CANCELLATIONS,
+        number='0323001',
+        account='15035382752',
+    )
+    assignment.add_payment_cancellation(**assignment_data)
+
+    records = list(transmission.to_records())
+
+    assert len(records) == 6
+
+    transmission_start = records[0]
+    assignment_start = records[1]
+    tx1_item1 = records[2]
+    tx1_item2 = records[3]
+    assignment_end = records[-2]
+    transmission_end = records[-1]
+
+    assert transmission_start.transmission_number == '1703231'
+    assert transmission_start.data_transmitter == '01234567'
+    assert transmission_start.data_recipient == netsgiro.NETS_ID
+    assert transmission_end.nets_date == date(2017, 4, 6)
+
+    assert assignment_start.assignment_number == '0323001'
+    assert assignment_start.assignment_account == '15035382752'
+    assert assignment_end.nets_date_earliest == date(2017, 4, 6)
+    assert assignment_end.nets_date_latest == date(2017, 4, 6)
+
+    assert tx1_item1.kid == '000133700501645'
+    assert tx1_item1.amount == 524463
+    assert tx1_item1.nets_date == date(2017, 4, 6)
+    assert tx1_item2.reference == 'ACME invoice #50164'
+    assert tx1_item2.payer_name == 'Wonderland'
+
+
+def test_transmission_add_payment_cancellation_assertions():
+    """
+    Test add_payment_cancellation guards.
+    """
+    transmission = netsgiro.Transmission(
+        number='1703231',
+        data_transmitter='01234567',
+        data_recipient=netsgiro.NETS_ID,
+    )
+    good_data = {
+        'service_code': netsgiro.ServiceCode.AVTALEGIRO,
+        'assignment_type': netsgiro.AssignmentType.AVTALEGIRO_CANCELLATIONS,
+        'number': '0323001',
+        'account': '15035382752',
+    }
+
+    # Test wrong service code
+    bad_service_code_assignment = transmission.add_assignment(
+        **(good_data | {'service_code': netsgiro.ServiceCode.OCR_GIRO})
+    )
+    with pytest.raises(AssertionError, match='Can only add cancellation to AvtaleGiro assignments'):
+        bad_service_code_assignment.add_payment_cancellation(**assignment_data)
+
+    # Test wrong assignment type
+    bad_assignment_type_assignment = transmission.add_assignment(
+        **(good_data | {'assignment_type': netsgiro.AssignmentType.AVTALEGIRO_AGREEMENTS})
+    )
+    with pytest.raises(
+        AssertionError, match='Can only add cancellation to cancellation assignments'
+    ):
+        bad_assignment_type_assignment.add_payment_cancellation(**assignment_data)

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -3,6 +3,8 @@ from datetime import date
 import pytest
 
 import netsgiro
+from netsgiro.objects import Transmission
+from netsgiro.records import AssignmentEnd
 
 
 @pytest.fixture
@@ -23,3 +25,14 @@ def test_transmission_from_zero_records_fails():
 def test_assignment_from_zero_records_fails():
     with pytest.raises(ValueError, match='At least 2 records required, got 0'):
         netsgiro.Assignment.from_records([])
+
+
+def test_transmission__get_assignments_validation():
+    assignment_end = AssignmentEnd.from_string(
+        'NY210088000000060000002000000000000000600170604170604000000000000000000000000000'
+    )
+
+    # Check that we fail if the first item is not an `AssignmentStart` instance
+    for item in ['test', assignment_end]:
+        with pytest.raises(ValueError, match='Expected AssignmentStart record, got '):
+            Transmission._get_assignments([item])

--- a/tests/test_record_parsing.py
+++ b/tests/test_record_parsing.py
@@ -14,6 +14,7 @@ from netsgiro.records import (
     AssignmentEnd,
     AssignmentStart,
     AvtaleGiroAgreement,
+    Record,
     TransactionAmountItem1,
     TransactionAmountItem2,
     TransactionAmountItem3,
@@ -390,3 +391,44 @@ def test_avtalegiro_new_or_updated_agreement():
     assert record.registration_type == AvtaleGiroRegistrationType.NEW_OR_UPDATED_AGREEMENT
     assert record.kid == '008000011688373'
     assert record.notify is False
+
+
+def test__split_text_to_lines_and_columns_validation():
+    """
+    Make sure the validation in
+    TransactionSpecification._split_text_to_lines_and_columns_validation works.
+    """
+    # Test <= max line count
+    for i in [0, 1, 42]:
+        for _ in TransactionSpecification._split_text_to_lines_and_columns('test\n' * i):
+            pass
+
+    # Test > max line count
+    for i in [43, 100, 1000]:
+        with pytest.raises(ValueError, match='Max 42 specification lines allowed'):
+            for _ in TransactionSpecification._split_text_to_lines_and_columns('test\n' * i):
+                pass
+
+    # Test <= max line length
+    for i in [0, 1, 80]:
+        for _ in TransactionSpecification._split_text_to_lines_and_columns('i' * i):
+            pass
+
+    # Test > max line length
+    for i in [81, 100, 1000]:
+        with pytest.raises(ValueError, match='Specification lines must be max 80 chars long'):
+            for _ in TransactionSpecification._split_text_to_lines_and_columns('i' * i):
+                pass
+
+
+def test_record__to_ocr():
+    """Test that the record to_ocr abstract method is required."""
+
+    class SomeRecordDerivative(Record):
+        ...
+
+    with pytest.raises(
+        TypeError,
+        match="Can't instantiate abstract class SomeRecordDerivative with abstract method to_ocr",
+    ):
+        SomeRecordDerivative()


### PR DESCRIPTION
Pads our coverage a little by testing untested code, and ignoring code we cannot test.

### Alternative to `no cover`

We could also remove the unreachable code, but I think it largely makes sense to keep it. 

An example of unreachable code is stuff like:

```python
class Assignment:
    ... 

    def _get_end_record(self):
        if self.service_code == ServiceCode.OCR_GIRO:
            ...
        elif self.service_code == ServiceCode.AVTALEGIRO:
            ...
        else:  # pragma: no cover
            raise ValueError(f'Unhandled service code: {self.service_code}')
```

The conditions here are specified on a class method that only allows the first two options for `self.service_code` and would otherwise crash on initialization. In that sense the code is unreachable, but keeping it seems preferable to making it an if/else, since it makes the library more robust in case of future mistakes.